### PR TITLE
CIWEMB-248: Add API V4 endpoint to switch recurring contribution to automated direct debit payment scheme

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Installing Automated Direct Debit extension and its dependencies
         working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}
         run: |
-          git clone --depth 1 https://github.com/compucorp/uk.co.compucorp.membershipextras.git
+          git clone -b CIWEMB-84-workstream --depth 1 https://github.com/compucorp/uk.co.compucorp.membershipextras.git
           cv en uk.co.compucorp.membershipextras io.compuco.automateddirectdebit
 
       - name: Run phpunit tests

--- a/Civi/Api4/Action/AutoDirectDebitPaymentPlan/SwitchToDirectDebitPaymentScheme.php
+++ b/Civi/Api4/Action/AutoDirectDebitPaymentPlan/SwitchToDirectDebitPaymentScheme.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Civi\Api4\Action\AutoDirectDebitPaymentPlan;
+
+use Civi\Api4\Generic\Result;
+
+/**
+ * Action for switching a recurring contribution
+ * to new payment scheme that supports automated
+ * direct debit.
+ *
+ * The action mainly:
+ * - Links the new payment scheme to the recurring contribution.
+ * - Updates the recurring contribution payment processor
+ *   to match the one configured on the new payment scheme.
+ * - Updates the external mandate information.
+ * - Unsets fields like installments and frequency_unit on
+ *   the recurring contribution given they are not needed
+ *   for payment scheme enabled payment plans.
+ *
+ * @see \Civi\Api4\Generic\AbstractAction
+ *
+ * @package Civi\Api4\Action\AutoDirectDebitPaymentPlan
+ */
+class SwitchToDirectDebitPaymentScheme extends \Civi\Api4\Generic\AbstractAction {
+
+  /**
+   * @var int
+   * @required
+   */
+  protected $contributionRecurId;
+
+  /**
+   * @var int
+   * @required
+   */
+  protected $paymentSchemeID;
+
+  /**
+   * @var string
+   * @required
+   */
+  protected $mandateId;
+
+  /**
+   * @var int
+   * @required
+   */
+  protected $mandateStatus;
+
+  /**
+   * @var string
+   * @required
+   */
+  protected $nextAvailablePaymentDate;
+
+  /**
+   * @inheritDoc
+   */
+  public function _run(Result $result) {
+    $paymentScheme = \Civi\Api4\PaymentScheme::get()
+      ->addSelect('payment_processor')
+      ->addWhere('id', '=', $this->paymentSchemeID)
+      ->setLimit(1)
+      ->execute();
+    if (empty($paymentScheme[0])) {
+      throw new \CRM_Core_Exception('Invalid payment scheme id.');
+    }
+    $newPaymentProcessorId = $paymentScheme[0]['payment_processor'];
+
+    return \Civi\Api4\ContributionRecur::update()
+      ->addValue('payment_processor_id', $newPaymentProcessorId)
+      ->addValue('installments', NULL)
+      ->addValue('frequency_unit', NULL)
+      ->addValue('frequency_interval', NULL)
+      ->addValue('payment_plan_extra_attributes.payment_scheme_id', $this->paymentSchemeID)
+      ->addValue('external_direct_debit_mandate_information.mandate_id', $this->mandateId)
+      ->addValue('external_direct_debit_mandate_information.mandate_status', $this->mandateStatus)
+      ->addValue('external_direct_debit_mandate_information.next_available_payment_date', $this->nextAvailablePaymentDate)
+      ->addWhere('id', '=', $this->contributionRecurId)
+      ->execute();
+  }
+
+  /**
+   * @inheritDoc
+   *
+   * @return array
+   */
+  public static function fields() {
+    return [
+      ['name' => 'contributionRecurId', 'data_type' => 'Integer'],
+      ['name' => 'paymentSchemeID', 'data_type' => 'Integer'],
+      ['name' => 'mandateId', 'data_type' => 'String'],
+      ['name' => 'mandateStatus', 'data_type' => 'Integer'],
+      ['name' => 'nextAvailablePaymentDate', 'data_type' => 'Date'],
+    ];
+  }
+
+}

--- a/Civi/Api4/AutoDirectDebitPaymentPlan.php
+++ b/Civi/Api4/AutoDirectDebitPaymentPlan.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Civi\Api4;
+
+/**
+ *
+ * @package Civi\Api4
+ */
+class AutoDirectDebitPaymentPlan extends Generic\AbstractEntity {
+
+  /**
+   * @inheritDoc
+   */
+  public static function getFields() {
+    return (new Generic\BasicGetFieldsAction(__CLASS__, __FUNCTION__, function($getFieldsAction) {
+      return [];
+    }));
+  }
+
+}

--- a/tests/phpunit/CRM/Api4/AutoDirectDebitPaymentPlanTest.php
+++ b/tests/phpunit/CRM/Api4/AutoDirectDebitPaymentPlanTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * Unit test for the Example entity
+ * @group headless
+ */
+class CRM_Api4_AutoDirectDebitPaymentPlanTest extends BaseHeadlessTest {
+
+  private $recurringContribution;
+
+  private $paymentScheme;
+
+  public function setUp() {
+    $this->recurringContribution = \Civi\Api4\ContributionRecur::create()
+      ->addValue('contact_id', 1)
+      ->addValue('amount', 100)
+      ->addValue('is_test', FALSE)
+      ->addValue('installments', 12)
+      ->addValue('frequency_unit', 'month')
+      ->addValue('frequency_interval', 1)
+      ->addValue('payment_processor', 2)
+      ->execute()[0];
+
+    $this->paymentScheme = \Civi\Api4\PaymentScheme::create()
+      ->addValue('name', 'testscheme')
+      ->addValue('admin_title', 'Test Scheme')
+      ->addValue('public_title', 'Test Scheme')
+      ->addValue('permission', 'public')
+      ->addValue('parameters', '{}')
+      ->addValue('payment_processor', 1)
+      ->execute()[0];
+
+    \Civi\Api4\AutoDirectDebitPaymentPlan::switchToDirectDebitPaymentScheme()
+      ->setContributionRecurId($this->recurringContribution['id'])
+      ->setPaymentSchemeID($this->paymentScheme['id'])
+      ->setMandateId('MAND_00001')
+      ->setMandateStatus(1)
+      ->setNextAvailablePaymentDate('2023-01-01')
+      ->execute();
+  }
+
+  public function testSwitchToDirectDebitPaymentSchemeChangeTheRecurringContributionPaymentProcessorToThePaymentSchemeOne() {
+    $recurringContributionAfterSwitch = \Civi\Api4\ContributionRecur::get()
+      ->addSelect('payment_processor_id')
+      ->addWhere('id', '=', $this->recurringContribution['id'])
+      ->setLimit(1)
+      ->execute()[0];
+
+    $this->assertEquals(1, $recurringContributionAfterSwitch['payment_processor_id']);
+  }
+
+  public function testSwitchToDirectDebitPaymentSchemeWillUnsetIrrelevantRecurringContributionFields() {
+    $recurringContributionAfterSwitch = \Civi\Api4\ContributionRecur::get()
+      ->addSelect('installments', 'frequency_unit', 'frequency_interval')
+      ->addWhere('id', '=', $this->recurringContribution['id'])
+      ->setLimit(1)
+      ->execute()[0];
+
+    $this->assertEmpty($recurringContributionAfterSwitch['installments']);
+    $this->assertEmpty($recurringContributionAfterSwitch['frequency_unit']);
+    $this->assertEmpty($recurringContributionAfterSwitch['frequency_interval']);
+  }
+
+  public function testSwitchToDirectDebitPaymentSchemeLinksTheRecurringContributionToThePaymentScheme() {
+    $recurringContributionAfterSwitch = \Civi\Api4\ContributionRecur::get()
+      ->addSelect('payment_plan_extra_attributes.payment_scheme_id')
+      ->addWhere('id', '=', $this->recurringContribution['id'])
+      ->setLimit(1)
+      ->execute()[0];
+
+    $this->assertEquals($this->paymentScheme['id'], $recurringContributionAfterSwitch['payment_plan_extra_attributes.payment_scheme_id']);
+  }
+
+  public function testSwitchToDirectDebitPaymentSchemeSetsTheRecurringContributionExternalMandateInformation() {
+    $recurringContributionAfterSwitch = \Civi\Api4\ContributionRecur::get()
+      ->addSelect('external_direct_debit_mandate_information.mandate_id')
+      ->addSelect('external_direct_debit_mandate_information.mandate_status')
+      ->addSelect('external_direct_debit_mandate_information.next_available_payment_date')
+      ->addWhere('id', '=', $this->recurringContribution['id'])
+      ->setLimit(1)
+      ->execute()[0];
+
+    $this->assertEquals('MAND_00001', $recurringContributionAfterSwitch['external_direct_debit_mandate_information.mandate_id']);
+    $this->assertEquals(1, $recurringContributionAfterSwitch['external_direct_debit_mandate_information.mandate_status']);
+    $this->assertEquals('2023-01-01', $recurringContributionAfterSwitch['external_direct_debit_mandate_information.next_available_payment_date']);
+  }
+
+}


### PR DESCRIPTION
## Overview

Adding new API v4 endpoint to switch a recurring contribution to new payment scheme that supports automated direct debit payments.

## Before

--

## After

New API v4 endpoint is added:

`AutoDirectDebitPaymentPlan`

with an action called:

`SwitchToDirectDebitPaymentScheme`

that takes the following mandatory fields:

- `contributionRecurId`
- `paymentSchemeID`
- `mandateId`
- `mandateStatus`
- `nextAvailablePaymentDate`

![image](https://user-images.githubusercontent.com/6275540/230037638-ccfbd1f6-ceb0-451d-9c4d-6148a3d1bafd.png)


Reason is; we will have a place in the SSP that will allow users to switch their payment plan to new scheme that supports automated direct debit (using payment processors like GoCardless and Stripe), this API facilitates that action by taking all the information necessary for such switch and update the recurring contribution (payment plan)  accordingly, such switch includes the following action (which is all encapsulated within this new API)

1- Changing the payment_processor_id on the recurring contribution to match the one configured on the input payment scheme.
2- Emptying the following recurring contribution fields (installments, frequency_unit, frequency_interval), given they won't be needed for payment scheme enabled payment plans, and keeping their values as is might confuse the users.
3- Linking the input payment scheme to the recurring contribution.
4- Updating the recurring contribution external mandate information, mainly the mandate  id, the mandate status and the mandate next available payment date.

