### PR TITLE
[WIP] CIWEMB-255: Create scheduled Job that dispatch 'advance notice' event hook for pending payments

### DIFF
--- a/CRM/Automateddirectdebit/Job/DirectDebitEvents/AdvanceNoticeEvent.php
+++ b/CRM/Automateddirectdebit/Job/DirectDebitEvents/AdvanceNoticeEvent.php
@@ -1,0 +1,63 @@
+<?php
+
+use CRM_Automateddirectdebit_Job_DirectDebitEvents_PendingContributionsQueryBuilder as PendingContributionsQueryBuilder;
+
+/**
+ * Responsible for sending direct debit advance notice notifications
+ * event, the class does not send the notifications itself,
+ * but rather dispatch a hook called: `automateddirectdebit_AdvanceNoticeEvent`
+ * that 3rd party payment processor extensions can implement, so such extensions
+ * can have more control over how such notifications can be sent.
+ *
+ */
+class CRM_Automateddirectdebit_Job_DirectDebitEvents_AdvanceNoticeEvent {
+
+  /**
+   * How many days before the payment should
+   * the user by notified about when the payment
+   * will be taken.
+   *
+   * todo: it is hardcoded for now, but we should probably expose it as a setting in the UI.
+   */
+  const DAYS_TO_NOTIFY_IN_ADVANCE = 10;
+
+  public function run() {
+    $pendingContributions = $this->getPendingContributionsForAdvanceNotice();
+    foreach ($pendingContributions as $pendingContribution) {
+      $this->dispatchAdvanceNoticeEventHook($pendingContribution);
+    }
+  }
+
+  private function getPendingContributionsForAdvanceNotice() {
+    $daysToNotifyInAdvance = self::DAYS_TO_NOTIFY_IN_ADVANCE;
+    $query = PendingContributionsQueryBuilder::buildQuery();
+    $query->where("c.receive_date = DATE_SUB(mandate.next_available_payment_date, INTERVAL {$daysToNotifyInAdvance} DAY)")
+      // todo: find out what data @Dome's wants and only select() that data here.
+      // todo: There is an extra condition needed here to only send notifications for unprocessed payments (we don't have the schema for such data yet)
+      ->select('c.*');
+
+    $pendingContributions = CRM_Core_DAO::executeQuery($query->toSQL());
+
+    $pendingContributionsList = [];
+    while ($pendingContributions->fetch()) {
+      // todo: find out what data @Dome's wants and add it here.
+      $pendingContributionsList[] = [
+        'contribution_id' => $pendingContributions->id,
+      ];
+    }
+
+    return $pendingContributionsList;
+  }
+
+  private function dispatchAdvanceNoticeEventHook($pendingContributionData) {
+    $nullObject = CRM_Utils_Hook::$_nullObject;
+    // todo: replace PLACEHOLDER with the data @Dome's
+    CRM_Utils_Hook::singleton()->invoke(
+      ['PLACEHOLDER'],
+      $pendingContributionData,
+      $nullObject, $nullObject, $nullObject, $nullObject, $nullObject,
+      'automateddirectdebit_AdvanceNoticeEvent'
+    );
+  }
+
+}

--- a/CRM/Automateddirectdebit/Job/DirectDebitEvents/PendingContributionsQueryBuilder.php
+++ b/CRM/Automateddirectdebit/Job/DirectDebitEvents/PendingContributionsQueryBuilder.php
@@ -1,0 +1,30 @@
+<?php
+
+class CRM_Automateddirectdebit_Job_DirectDebitEvents_PendingContributionsQueryBuilder {
+
+  /**
+   * Builds the main query to fetch the pending automated
+   * direct debit contributions. Consumers of this class
+   * can modify the query and add more filters according
+   * to their needs.
+   *
+   * @return CRM_Utils_SQL_Select
+   */
+  public static function buildQuery() {
+    $contributionPendingStatusID = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Pending');
+    $mandateActiveStatusId = 1;
+
+    $query = CRM_Utils_SQL_Select::from('civicrm_contribution c')
+      ->join('cr', 'INNER JOIN civicrm_contribution_recur cr ON c.contribution_recur_id = cr.id')
+      ->join('mandate', 'INNER JOIN civicrm_value_external_dd_mandate_information mandate ON cr.id = mandate.entity_id')
+      ->join('ppea', 'INNER JOIN civicrm_value_payment_plan_extra_attributes ppea ON cr.id = ppea.entity_id')
+      ->where("c.contribution_status_id = {$contributionPendingStatusID}")
+      ->where("mandate.mandate_id IS NOT NULL")
+      ->where('mandate.next_available_payment_date IS NOT NULL')
+      ->where("mandate.mandate_status = {$mandateActiveStatusId}")
+      ->where('ppea.is_active = 1');
+
+    return $query;
+  }
+
+}

--- a/CRM/Automateddirectdebit/Setup/Manage/ScheduledJob/AdvanceNoticeNotificationsJob.php
+++ b/CRM/Automateddirectdebit/Setup/Manage/ScheduledJob/AdvanceNoticeNotificationsJob.php
@@ -1,0 +1,53 @@
+<?php
+
+use CRM_MembershipExtras_Setup_Manage_AbstractManager as AbstractManager;
+
+/**
+ * Managing the 'Send Advance Notice Notifications' scheduled job.
+ */
+class CRM_Automateddirectdebit_Setup_Manage_ScheduledJob_AdvanceNoticeNotificationsJob extends AbstractManager {
+
+  const JOB_NAME = 'Send Direct Debit Advance Notice Notifications';
+
+  /**
+   * @inheritDoc
+   */
+  public function create() {
+    $result = civicrm_api3('Job', 'get', [
+      'name' => self::JOB_NAME,
+    ]);
+    if (!empty($result['id'])) {
+      return;
+    }
+
+    civicrm_api3('Job', 'create', [
+      'run_frequency' => 'Daily',
+      'name' => self::JOB_NAME,
+      'description' => ts('Automatically send Direct Debit advance notice notifications to customers with pending payments'),
+      'api_entity' => 'SendAdvanceNoticeNotificationJob',
+      'api_action' => 'run',
+      'is_active' => 0,
+    ]);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function remove() {
+    civicrm_api3('Job', 'get', [
+      'name' => self::JOB_NAME,
+      'api.Job.delete' => ['id' => '$value.id'],
+    ]);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  protected function toggle($status) {
+    civicrm_api3('Job', 'get', [
+      'name' => self::JOB_NAME,
+      'api.Job.create' => ['id' => '$value.id', 'is_active' => $status],
+    ]);
+  }
+
+}

--- a/CRM/Automateddirectdebit/Upgrader.php
+++ b/CRM/Automateddirectdebit/Upgrader.php
@@ -5,10 +5,21 @@
  */
 class CRM_Automateddirectdebit_Upgrader extends CRM_Automateddirectdebit_Upgrader_Base {
 
+  public function postInstall() {
+    $creationSteps = [
+      new CRM_Automateddirectdebit_Setup_Manage_ScheduledJob_AdvanceNoticeNotificationsJob(),
+    ];
+
+    foreach ($creationSteps as $step) {
+      $step->create();
+    }
+  }
+
   public function enable() {
     $steps = [
       new CRM_Automateddirectdebit_Setup_Manage_CustomGroup_ExternalDDMandateInformation(),
     ];
+
     foreach ($steps as $step) {
       $step->activate();
     }
@@ -17,7 +28,9 @@ class CRM_Automateddirectdebit_Upgrader extends CRM_Automateddirectdebit_Upgrade
   public function disable() {
     $steps = [
       new CRM_Automateddirectdebit_Setup_Manage_CustomGroup_ExternalDDMandateInformation(),
+      new CRM_Automateddirectdebit_Setup_Manage_ScheduledJob_AdvanceNoticeNotificationsJob(),
     ];
+
     foreach ($steps as $step) {
       $step->deactivate();
     }
@@ -26,7 +39,9 @@ class CRM_Automateddirectdebit_Upgrader extends CRM_Automateddirectdebit_Upgrade
   public function uninstall() {
     $removalSteps = [
       new CRM_Automateddirectdebit_Setup_Manage_CustomGroup_ExternalDDMandateInformation(),
+      new CRM_Automateddirectdebit_Setup_Manage_ScheduledJob_AdvanceNoticeNotificationsJob(),
     ];
+
     foreach ($removalSteps as $step) {
       $step->remove();
     }

--- a/api/v3/SendAdvanceNoticeNotificationJob.php
+++ b/api/v3/SendAdvanceNoticeNotificationJob.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Auto Direct Debit Advance Notice Notifications scheduled job API
+ *
+ * @param $params
+ * @return array
+ */
+function civicrm_api3_send_advance_notice_notification_job_run($params) {
+  $lock = Civi::lockManager()->acquire('worker.automateddirectdebit.sendadvancenoticenotification');
+  if (!$lock->isAcquired()) {
+    return civicrm_api3_create_error("Could not acquire a lock, another 'Send Advance Notice Notifications' job is running");
+  }
+
+  try {
+    $advanceNoticeEventJob = new CRM_Automateddirectdebit_Job_DirectDebitEvents_AdvanceNoticeEvent();
+    $advanceNoticeEventJob->run();
+
+    $lock->release();
+
+    return civicrm_api3_create_success();
+  }
+  catch (Exception $error) {
+    $lock->release();
+    throw $error;
+  }
+}


### PR DESCRIPTION
Note: This PR is a work in progress that is still waiting the following:

1- For us to decide in how are going to proceed with CIWEMB-254, and based on that I will update the query that fetch the pending payments so it does not include payments that are already processed.
2- For @  Dome  to share with me what kind of data he needs to be passed by the hook.
3- Writing tests once the two notes above are resolved.

## Overview

Advance notice is one of the main protections offered by the Direct Debit guarantee. It requires you to give your customer notice of a Direct Debit payment before it’s taken from their account. See: https://gocardless.com/guides/posts/advance-notice/

In this PR I am creating new scheduled job called `Send Direct Debit Advance Notice Notifications`  that runs once a day, where it goes through all the contributions that are:

- Connected to a recurring contribution
- The Recurring contribution  with mandate_id that is not NULL and the mandate status = active
- The Recurring contribution (is_active) field is set to True.
- Contribution Status = Pending 
- The contribution receive_date is 3 days less than the mandate next_available_payment_date
- [**Still Not Done because we don't have the schema for it yet**] the payment status field is empty.

And for each contribution, the following hook will be dispatched:

```
 hook_automateddirectdebit_AdvanceNoticeEvent();
```

Which 3rd party payment processor extensions like GoCardless can implement to send the actual notification, the decision to use a hook was to allow the payment processor extensions to have control on how such notifications will be sent and what they will contain.