### PR TITLE
CIWEMB-405: Add payment collection retry count setting

### DIFF
--- a/CRM/Automateddirectdebit/Setup/Configure/ConfigurerInterface.php
+++ b/CRM/Automateddirectdebit/Setup/Configure/ConfigurerInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * Describes the interface for things we want to configure
+ * on existing entities or for configuring certain default settings
+ * during the extension installations.
+ *
+ */
+interface CRM_MembershipExtras_Setup_Configure_ConfigurerInterface {
+
+  /**
+   * Applies the configuration.
+   */
+  public function apply();
+
+}

--- a/CRM/Automateddirectdebit/Setup/Configure/SetPaymentCollectionRetryCountDefaultValue.php
+++ b/CRM/Automateddirectdebit/Setup/Configure/SetPaymentCollectionRetryCountDefaultValue.php
@@ -1,0 +1,16 @@
+<?php
+
+use CRM_MembershipExtras_Setup_Configure_ConfigurerInterface as ConfigurerInterface;
+
+/**
+ * Sets the default value for "Payment collection number of retry attempts"
+ * setting.
+ *
+ */
+class CRM_Automateddirectdebit_Setup_Configure_SetPaymentCollectionRetryCountDefaultValue implements ConfigurerInterface {
+
+  public function apply() {
+    \Civi::settings()->set('automateddirectdebit_paymentplan_payment_collection_retry_count', 3);
+  }
+
+}

--- a/CRM/Automateddirectdebit/Upgrader.php
+++ b/CRM/Automateddirectdebit/Upgrader.php
@@ -5,6 +5,15 @@
  */
 class CRM_Automateddirectdebit_Upgrader extends CRM_Automateddirectdebit_Upgrader_Base {
 
+  public function postInstall() {
+    $configurationSteps = [
+      new CRM_Automateddirectdebit_Setup_Configure_SetPaymentCollectionRetryCountDefaultValue(),
+    ];
+    foreach ($configurationSteps as $step) {
+      $step->apply();
+    }
+  }
+
   public function enable() {
     $steps = [
       new CRM_Automateddirectdebit_Setup_Manage_CustomGroup_ExternalDDMandateInformation(),

--- a/settings/AutomatedDirectDebit.setting.php
+++ b/settings/AutomatedDirectDebit.setting.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * Settings Metadata
+ */
+return [
+  'automateddirectdebit_paymentplan_payment_collection_retry_count' => [
+    'group_name' => 'MembershipExtras: Payment Plan',
+    'group' => 'membershipextras_paymentplan',
+    'name' => 'automateddirectdebit_paymentplan_payment_collection_retry_count',
+    'title' => 'Payment collection number of retry attempts',
+    'type' => 'Integer',
+    'html_type' => 'text',
+    'quick_form_type' => 'Element',
+    'default' => 3,
+    'is_required' => TRUE,
+  ],
+];

--- a/templates/CRM/MembershipExtras/Form/PaymentPlanSettings.extra.hlp
+++ b/templates/CRM/MembershipExtras/Form/PaymentPlanSettings.extra.hlp
@@ -1,0 +1,8 @@
+{htxt id="automateddirectdebit_paymentplan_payment_collection_retry_count-title"}
+{ts}Payment collection number of retry attempts{/ts}
+{/htxt}
+{htxt id="automateddirectdebit_paymentplan_payment_collection_retry_count"}
+{ts}Please configure the number of retry attempts that CiviCRM will make before marking the recurring contribution as failed.{/ts}
+{ts}Note however that your payment processor, for example GoCardless, may already attempt to retry your payment before CiviCRM attempts to retry.{/ts}
+{ts}In those situations you may wish to set this to 0 as GoCardless will already have retried the payment on your behalf.{/ts}
+{/htxt}

--- a/tests/phpunit/CRM/Api4/AutoDirectDebitPaymentPlanTest.php
+++ b/tests/phpunit/CRM/Api4/AutoDirectDebitPaymentPlanTest.php
@@ -28,6 +28,7 @@ class CRM_Api4_AutoDirectDebitPaymentPlanTest extends BaseHeadlessTest {
       ->addValue('permission', 'public')
       ->addValue('parameters', '{}')
       ->addValue('payment_processor', 1)
+      ->addValue('public_description', 'test')
       ->execute()[0];
 
     \Civi\Api4\AutoDirectDebitPaymentPlan::switchToDirectDebitPaymentScheme()


### PR DESCRIPTION
## Overview

Adding a new setting "Payment collection number of retry attempts" to the "Payment Plan Settings" form, which will be used in future work to control the number of times we are going to try to submit payments for pending invoices against payment processors (such as GoCardless). 

## Before

![image](https://github.com/compucorp/io.compuco.automateddirectdebit/assets/6275540/384d36e3-445a-4d76-bb8c-35165989183d)


## After

The new field is added after installing this extension with default value = 3 and with the following help text:

![2023-07-19 22_42_27-Payment Plan Settings _ compuclient22sspv3](https://github.com/compucorp/io.compuco.automateddirectdebit/assets/6275540/28a4fb35-7402-4252-9052-b8ca9f805654)


This setting has no effect on anything yet, but as mentioned above will be used in future work.

## Technical Details

- Given we wanted to add this setting to the "Payment Plan Settings" form which is controlled by Membershipextras extension, I've defined the group for this setting to be the same group as other settings in Membershipextras (which is `membershipextras_paymentplan`), so it ended getting added by default to that form (given the form controller in Membershipextras and by default adds any setting that is part of `membershipextras_paymentplan` group` to the "Payment Plan Settings" form ).

- For the help text, I used CiviCRM `*.extra.tpl` & `*.extra.hlp` feature (https://docs.civicrm.org/dev/en/latest/framework/templates/#appending-jquery-or-other-code-to-a-template) to define it.

- The postInstall hook is also used to set the default value for this new setting upon the extension installation.
