### PR TITLE
CIWEMB-346: Create scheduled job to send payment collection events

### DIFF
--- a/CRM/Automateddirectdebit/Job/DirectDebitEvents/PaymentCollectionEvent.php
+++ b/CRM/Automateddirectdebit/Job/DirectDebitEvents/PaymentCollectionEvent.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * Responsible for emitting direct debit payment collection event (hook).
+ * The dispatched event/hook is called: `automateddirectdebit_PaymentCollectionEvent`
+ * where 3rd party payment processor extensions (such as GoCardless extension) can implement it
+ * to create and collect payments.
+ *
+ */
+class CRM_Automateddirectdebit_Job_DirectDebitEvents_PaymentCollectionEvent {
+
+  public function run() {
+    $pendingInvoicesQuery = $this->buildPendingInvoicesQuery();
+    $pendingInvoices = CRM_Core_DAO::executeQuery($pendingInvoicesQuery->toSQL());
+
+    while ($pendingInvoices->fetch()) {
+      $pendingInvoiceData = $pendingInvoices->toArray();
+      $invoiceTotalPaidAmount = CRM_Core_BAO_FinancialTrxn::getTotalPayments($pendingInvoiceData['contribution_id'], TRUE);
+      if ($invoiceTotalPaidAmount >= $pendingInvoiceData['total_amount']) {
+        continue;
+      }
+
+      $pendingInvoiceData['charge_amount'] = $pendingInvoiceData['total_amount'] - $invoiceTotalPaidAmount;
+
+      $this->markContributionExternalPaymentToBeInProgress($pendingInvoices['contribution_id']);
+      $this->dispatchPaymentCollectionEventHook($pendingInvoices);
+    }
+  }
+
+  /**
+   * Builds the query to fetch the contributions (invoices)
+   * that match the criteria of invoices that we
+   *
+   * @return CRM_Utils_SQL_Select
+   */
+  public function buildPendingInvoicesQuery() {
+    $recurContributionStatusesToProcess = implode(',', $this->getRecurContributionStatusesIdsToProcess());
+    $mandateActiveStatusId = 1;
+    $failureRetryCount = \Civi::settings()->get('automateddirectdebit_paymentplan_payment_collection_retry_count');
+    $todaysDate = date('Y-m-d 00:00:00');
+
+    $query = CRM_Utils_SQL_Select::from('civicrm_contribution c')
+      ->join('cr', 'INNER JOIN civicrm_contribution_recur cr ON c.contribution_recur_id = cr.id')
+      ->join('mandate', 'INNER JOIN civicrm_value_external_dd_mandate_information mandate ON cr.id = mandate.entity_id')
+      ->join('ppea', 'INNER JOIN civicrm_value_payment_plan_extra_attributes ppea ON cr.id = ppea.entity_id')
+      ->join('epi', 'INNER JOIN civicrm_value_external_dd_payment_information epi ON c.id = epi.entity_id')
+      ->where("mandate.mandate_id IS NOT NULL")
+      ->where("mandate.mandate_status = {$mandateActiveStatusId}")
+      ->where('ppea.is_active = 1')
+      ->where("cr.contribution_status_id IN ({$recurContributionStatusesToProcess})")
+      ->where('mandate.next_available_payment_date IS NOT NULL')
+      ->where('c.receive_date >= mandate.next_available_payment_date')
+      ->where("c.receive_date <= {$todaysDate}")
+      ->where('epi.payment_in_progress = 0 OR epi.payment_in_progress IS NULL')
+      ->where("cr.failure_count <= {$failureRetryCount}")
+      ->select('c.id as contribution_id, c.contact_id, c.receive_date, c.total_amount, c.currency, mandate.id as mandate_id');
+
+    return $query;
+  }
+
+  private function getRecurContributionStatusesIdsToProcess() {
+    $allStatuses = CRM_Core_OptionGroup::values('contribution_recur_status', FALSE, FALSE, FALSE, NULL, 'name');
+    $statusesNamesToProcess = ['Pending', 'In Progress', 'Overdue'];
+    $statusesIdsToProcess = [];
+    foreach ($allStatuses as $key => $val) {
+      if (array_search($val, $statusesNamesToProcess) !== FALSE) {
+        $statusesIdsToProcess[] = $key;
+      }
+    }
+
+    return $statusesIdsToProcess;
+  }
+
+  /**
+   * Sets  the contribution "Payment In Progress" to True to prevent
+   * this class from trying to submit more than one payment against the
+   * same contribution.
+   *
+   * @param $contributionId
+   * @return void
+   */
+  private function markContributionExternalPaymentToBeInProgress($contributionId) {
+    $query = "INSERT INTO civicrm_value_external_dd_payment_information (entity_id, payment_in_progress) VALUES({$contributionId}, 1) ON DUPLICATE KEY UPDATE payment_in_progress= 1";
+    CRM_Core_DAO::executeQuery($query);
+  }
+
+  private function dispatchPaymentCollectionEventHook($pendingInvoiceData) {
+    $nullObject = CRM_Utils_Hook::$_nullObject;
+    $contributionData = [
+      'id' => $pendingInvoiceData['contribution_id'],
+      'contact_id' => $pendingInvoiceData['contact_id'],
+      'receive_date' => $pendingInvoiceData['receive_date'],
+      'total_amount' => $pendingInvoiceData['total_amount'],
+      'currency' => $pendingInvoiceData['currency'],
+    ];
+
+    $chargeAmount = $pendingInvoiceData['charge_amount'];
+    $mandateId = $pendingInvoiceData['mandate_id'];
+
+    CRM_Utils_Hook::singleton()->invoke(
+      ['contributionData', 'chargeAmount', 'mandateId'],
+      $contributionData, $chargeAmount, $mandateId,
+      $nullObject, $nullObject, $nullObject,
+      'automateddirectdebit_PaymentCollectionEvent'
+    );
+  }
+
+}

--- a/CRM/Automateddirectdebit/Job/DirectDebitEvents/PaymentCollectionEvent.php
+++ b/CRM/Automateddirectdebit/Job/DirectDebitEvents/PaymentCollectionEvent.php
@@ -22,8 +22,8 @@ class CRM_Automateddirectdebit_Job_DirectDebitEvents_PaymentCollectionEvent {
 
       $pendingInvoiceData['charge_amount'] = $pendingInvoiceData['total_amount'] - $invoiceTotalPaidAmount;
 
-      $this->markContributionExternalPaymentToBeInProgress($pendingInvoices['contribution_id']);
-      $this->dispatchPaymentCollectionEventHook($pendingInvoices);
+      $this->markContributionExternalPaymentToBeInProgress($pendingInvoiceData['contribution_id']);
+      $this->dispatchPaymentCollectionEventHook($pendingInvoiceData);
     }
   }
 
@@ -43,14 +43,14 @@ class CRM_Automateddirectdebit_Job_DirectDebitEvents_PaymentCollectionEvent {
       ->join('cr', 'INNER JOIN civicrm_contribution_recur cr ON c.contribution_recur_id = cr.id')
       ->join('mandate', 'INNER JOIN civicrm_value_external_dd_mandate_information mandate ON cr.id = mandate.entity_id')
       ->join('ppea', 'INNER JOIN civicrm_value_payment_plan_extra_attributes ppea ON cr.id = ppea.entity_id')
-      ->join('epi', 'INNER JOIN civicrm_value_external_dd_payment_information epi ON c.id = epi.entity_id')
+      ->join('epi', 'LEFT JOIN civicrm_value_external_dd_payment_information epi ON c.id = epi.entity_id')
       ->where("mandate.mandate_id IS NOT NULL")
       ->where("mandate.mandate_status = {$mandateActiveStatusId}")
       ->where('ppea.is_active = 1')
       ->where("cr.contribution_status_id IN ({$recurContributionStatusesToProcess})")
       ->where('mandate.next_available_payment_date IS NOT NULL')
       ->where('c.receive_date >= mandate.next_available_payment_date')
-      ->where("c.receive_date <= {$todaysDate}")
+      ->where("c.receive_date <= '{$todaysDate}'")
       ->where('epi.payment_in_progress = 0 OR epi.payment_in_progress IS NULL')
       ->where("cr.failure_count <= {$failureRetryCount}")
       ->select('c.id as contribution_id, c.contact_id, c.receive_date, c.total_amount, c.currency, mandate.id as mandate_id');

--- a/CRM/Automateddirectdebit/Setup/Manage/ScheduledJob/PaymentCollectionJob.php
+++ b/CRM/Automateddirectdebit/Setup/Manage/ScheduledJob/PaymentCollectionJob.php
@@ -5,8 +5,7 @@ use CRM_MembershipExtras_Setup_Manage_AbstractManager as AbstractManager;
 /**
  * Managing the 'Payment Collection' scheduled job.
  */
-class CRM_Automateddirectdebit_Setup_Manage_ScheduledJob_PaymentCollectionJob extends AbstractManager
-{
+class CRM_Automateddirectdebit_Setup_Manage_ScheduledJob_PaymentCollectionJob extends AbstractManager {
 
   const JOB_NAME = 'External Direct Debit Payment Collection';
 
@@ -34,8 +33,7 @@ class CRM_Automateddirectdebit_Setup_Manage_ScheduledJob_PaymentCollectionJob ex
   /**
    * @inheritDoc
    */
-  public function remove()
-  {
+  public function remove() {
     civicrm_api3('Job', 'get', [
       'name' => self::JOB_NAME,
       'api.Job.delete' => ['id' => '$value.id'],
@@ -45,8 +43,7 @@ class CRM_Automateddirectdebit_Setup_Manage_ScheduledJob_PaymentCollectionJob ex
   /**
    * @inheritDoc
    */
-  protected function toggle($status)
-  {
+  protected function toggle($status) {
     civicrm_api3('Job', 'get', [
       'name' => self::JOB_NAME,
       'api.Job.create' => ['id' => '$value.id', 'is_active' => $status],

--- a/CRM/Automateddirectdebit/Setup/Manage/ScheduledJob/PaymentCollectionJob.php
+++ b/CRM/Automateddirectdebit/Setup/Manage/ScheduledJob/PaymentCollectionJob.php
@@ -24,7 +24,7 @@ class CRM_Automateddirectdebit_Setup_Manage_ScheduledJob_PaymentCollectionJob ex
       'run_frequency' => 'Daily',
       'name' => self::JOB_NAME,
       'description' => ts('This job allows for collecting payments using external direct debit payment processors (such as GoCardless).'),
-      'api_entity' => 'ExternalDDPaymentCollectionJob',
+      'api_entity' => 'ExternalDirectDebitPaymentCollectionJob',
       'api_action' => 'run',
       'is_active' => 0,
     ]);

--- a/CRM/Automateddirectdebit/Setup/Manage/ScheduledJob/PaymentCollectionJob.php
+++ b/CRM/Automateddirectdebit/Setup/Manage/ScheduledJob/PaymentCollectionJob.php
@@ -1,0 +1,56 @@
+<?php
+
+use CRM_MembershipExtras_Setup_Manage_AbstractManager as AbstractManager;
+
+/**
+ * Managing the 'Payment Collection' scheduled job.
+ */
+class CRM_Automateddirectdebit_Setup_Manage_ScheduledJob_PaymentCollectionJob extends AbstractManager
+{
+
+  const JOB_NAME = 'External Direct Debit Payment Collection';
+
+  /**
+   * @inheritDoc
+   */
+  public function create() {
+    $result = civicrm_api3('Job', 'get', [
+      'name' => self::JOB_NAME,
+    ]);
+    if (!empty($result['id'])) {
+      return;
+    }
+
+    civicrm_api3('Job', 'create', [
+      'run_frequency' => 'Daily',
+      'name' => self::JOB_NAME,
+      'description' => ts('This job allows for collecting payments using external direct debit payment processors (such as GoCardless).'),
+      'api_entity' => 'ExternalDDPaymentCollectionJob',
+      'api_action' => 'run',
+      'is_active' => 0,
+    ]);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function remove()
+  {
+    civicrm_api3('Job', 'get', [
+      'name' => self::JOB_NAME,
+      'api.Job.delete' => ['id' => '$value.id'],
+    ]);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  protected function toggle($status)
+  {
+    civicrm_api3('Job', 'get', [
+      'name' => self::JOB_NAME,
+      'api.Job.create' => ['id' => '$value.id', 'is_active' => $status],
+    ]);
+  }
+
+}

--- a/CRM/Automateddirectdebit/Upgrader.php
+++ b/CRM/Automateddirectdebit/Upgrader.php
@@ -6,6 +6,13 @@
 class CRM_Automateddirectdebit_Upgrader extends CRM_Automateddirectdebit_Upgrader_Base {
 
   public function postInstall() {
+    $creationSteps = [
+      new CRM_Automateddirectdebit_Setup_Manage_ScheduledJob_PaymentCollectionJob(),
+    ];
+    foreach ($creationSteps as $step) {
+      $step->create();
+    }
+
     $configurationSteps = [
       new CRM_Automateddirectdebit_Setup_Configure_SetPaymentCollectionRetryCountDefaultValue(),
     ];
@@ -18,6 +25,7 @@ class CRM_Automateddirectdebit_Upgrader extends CRM_Automateddirectdebit_Upgrade
     $steps = [
       new CRM_Automateddirectdebit_Setup_Manage_CustomGroup_ExternalDDMandateInformation(),
       new CRM_Automateddirectdebit_Setup_Manage_CustomGroup_ExternalDDPaymentInformation(),
+      new CRM_Automateddirectdebit_Setup_Manage_ScheduledJob_PaymentCollectionJob(),
     ];
     foreach ($steps as $step) {
       $step->activate();
@@ -28,6 +36,7 @@ class CRM_Automateddirectdebit_Upgrader extends CRM_Automateddirectdebit_Upgrade
     $steps = [
       new CRM_Automateddirectdebit_Setup_Manage_CustomGroup_ExternalDDMandateInformation(),
       new CRM_Automateddirectdebit_Setup_Manage_CustomGroup_ExternalDDPaymentInformation(),
+      new CRM_Automateddirectdebit_Setup_Manage_ScheduledJob_PaymentCollectionJob(),
     ];
     foreach ($steps as $step) {
       $step->deactivate();
@@ -38,6 +47,7 @@ class CRM_Automateddirectdebit_Upgrader extends CRM_Automateddirectdebit_Upgrade
     $removalSteps = [
       new CRM_Automateddirectdebit_Setup_Manage_CustomGroup_ExternalDDMandateInformation(),
       new CRM_Automateddirectdebit_Setup_Manage_CustomGroup_ExternalDDPaymentInformation(),
+      new CRM_Automateddirectdebit_Setup_Manage_ScheduledJob_PaymentCollectionJob(),
     ];
     foreach ($removalSteps as $step) {
       $step->remove();

--- a/api/v3/ExternalDDPaymentCollectionJob.php
+++ b/api/v3/ExternalDDPaymentCollectionJob.php
@@ -1,0 +1,20 @@
+<?php
+
+function civicrm_api3_external_dd_payment_collection_job_run($params, $paymentCollectionEventJob)
+{
+  $lock = Civi::lockManager()->acquire('worker.automateddirectdebit.externalddpaymentcollection');
+  if (!$lock->isAcquired()) {
+    return civicrm_api3_create_error("Could not acquire a lock, another 'External Payment Collection' job is running");
+  }
+
+  try {
+    //todo
+
+    $lock->release();
+
+    return civicrm_api3_create_success();
+  } catch (Exception $error) {
+    $lock->release();
+    throw $error;
+  }
+}

--- a/api/v3/ExternalDDPaymentCollectionJob.php
+++ b/api/v3/ExternalDDPaymentCollectionJob.php
@@ -1,19 +1,20 @@
 <?php
 
-function civicrm_api3_external_dd_payment_collection_job_run($params, $paymentCollectionEventJob)
-{
+function civicrm_api3_external_dd_payment_collection_job_run($params, $paymentCollectionEventJob) {
   $lock = Civi::lockManager()->acquire('worker.automateddirectdebit.externalddpaymentcollection');
   if (!$lock->isAcquired()) {
     return civicrm_api3_create_error("Could not acquire a lock, another 'External Payment Collection' job is running");
   }
 
   try {
-    //todo
+    $paymentCollectionEventJob = new CRM_Automateddirectdebit_Job_DirectDebitEvents_PaymentCollectionEvent();
+    $paymentCollectionEventJob->run();
 
     $lock->release();
 
     return civicrm_api3_create_success();
-  } catch (Exception $error) {
+  }
+  catch (Exception $error) {
     $lock->release();
     throw $error;
   }

--- a/api/v3/ExternalDirectDebitPaymentCollectionJob.php
+++ b/api/v3/ExternalDirectDebitPaymentCollectionJob.php
@@ -1,6 +1,6 @@
 <?php
 
-function civicrm_api3_external_dd_payment_collection_job_run($params, $paymentCollectionEventJob) {
+function civicrm_api3_external_direct_debit_payment_collection_job_run($params) {
   $lock = Civi::lockManager()->acquire('worker.automateddirectdebit.externalddpaymentcollection');
   if (!$lock->isAcquired()) {
     return civicrm_api3_create_error("Could not acquire a lock, another 'External Payment Collection' job is running");


### PR DESCRIPTION
## Overview

Creating new scheduled job that runs over payment plan invoices (contributions) that adheres to certain criteria, and invokes hook that other payment processor extensions can implement so they can try and collect payments for these invoices.

## Before

~

## After

After installing the extension, a new scheduled job "External Direct Debit Payment Collection" will be created (disabled  by default to allow admins to enable it only once the site is ready):

![image](https://github.com/compucorp/io.compuco.automateddirectdebit/assets/6275540/168ac7e9-fcd7-431e-bc22-88d15f731577)

This scheduled job calls an API end point `ExternalDDPaymentCollectionJob.run` that processes the contributions (invoices) that match the following criteria: 


- Linked to a recurring contribution (civicrm_contribution.contribution_recur_id field is not NULL).
- Where the recurring contribution is linked to an external mandate (civicrm_value_external_dd_mandate_information.mandate_id field is not not null)
- And the mandate status is Active 
- And the recurring contribution is active (civicrm_value_payment_plan_extra_attributes.is_active  = True)
- And the recurring contribution status is either: (Pending. In Progress or Overdue)
- And the Contribution Total Amounts Paid < The contribution total amount
- And the Contributions receive date >= Mandate next available payment date
- And the Contributions receive date <= Today's date
- And the Contribution.External_payment_in_progress = No
- And the Recurring_contribution.failure_count  <= "Payment collection number of retry attempts" (which was added here: https://github.com/compucorp/io.compuco.automateddirectdebit/pull/6) as a configurable setting.

The end query will look something similar to this:

```
SELECT c.id as contribution_id, c.contact_id, c.receive_date, c.total_amount, c.currency, mandate.id as mandate_id
FROM civicrm_contribution c
INNER JOIN civicrm_contribution_recur cr ON c.contribution_recur_id = cr.id
INNER JOIN civicrm_value_external_dd_mandate_information mandate ON cr.id = mandate.entity_id
INNER JOIN civicrm_value_payment_plan_extra_attributes ppea ON cr.id = ppea.entity_id
LEFT JOIN civicrm_value_external_dd_payment_information epi ON c.id = epi.entity_id
WHERE (mandate.mandate_id IS NOT NULL) AND (mandate.mandate_status = 1) 
AND (ppea.is_active = 1) AND (cr.contribution_status_id IN (2,5,6))
AND (mandate.next_available_payment_date IS NOT NULL) 
AND (c.receive_date >= mandate.next_available_payment_date)
AND (c.receive_date <= '2023-07-24 00:00:00')
AND (epi.payment_in_progress = 0 OR epi.payment_in_progress IS NULL)
AND (cr.failure_count <= 3);
```


For all contributions that match the above criteria, we:

- Mark the Contribution.External_payment_in_progress to True to prevent it from being processed multiple times.
- Then we invoke the following hooks:

`hook_automateddirectdebit_PaymentCollectionEvent($contributionData, $chargeAmount, $mandateId)`

where:

- `$contributionData`: contains the following values: `id`, `contact_id`, `receive_date`, `total_amount` and `currency`.
- $chargeAmount: contains the remaining invoice amount due, which is the contribution total amount - the total of all payments and credit note allocations made against the invoice.
-  $mandateId: the external mandate id that is stored on the recurring contribution that is linked to the contribution.


Extensions like gocardless can implement this hook so they can try to collect the payment:

```
function gocardless_automateddirectdebit_PaymentCollectionEvent($contributionData, $chargeAmount, $mandateId) {
}
```

