### PR TITLE
CIWEMB-346: Make the recurring contribution status the main control point of the payment collection job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
   run-unit-tests:
 
     runs-on: ubuntu-latest
-    container: compucorp/civicrm-buildkit:1.3.0-php8.0
+    container: compucorp/civicrm-buildkit:1.3.1-php8.0
 
     env:
       CIVICRM_EXTENSIONS_DIR: site/web/sites/all/modules/civicrm/tools/extensions

--- a/CRM/Automateddirectdebit/Job/DirectDebitEvents/PaymentCollectionEvent.php
+++ b/CRM/Automateddirectdebit/Job/DirectDebitEvents/PaymentCollectionEvent.php
@@ -34,14 +34,7 @@ class CRM_Automateddirectdebit_Job_DirectDebitEvents_PaymentCollectionEvent {
    * @return CRM_Utils_SQL_Select
    */
   public function buildPendingInvoicesQuery() {
-    $mandateActiveStatusId = civicrm_api3('OptionValue', 'getvalue', [
-      'option_group_id' => 'automateddirectdebit_mandate_status',
-      'name' => 'active',
-      'return' => 'value',
-    ]);
-
     $recurContributionStatusesToProcess = implode(',', $this->getRecurContributionStatusesIdsToProcess());
-    $failureRetryCount = \Civi::settings()->get('automateddirectdebit_paymentplan_payment_collection_retry_count');
 
     $query = CRM_Utils_SQL_Select::from('civicrm_contribution c')
       ->join('cr', 'INNER JOIN civicrm_contribution_recur cr ON c.contribution_recur_id = cr.id')
@@ -49,14 +42,11 @@ class CRM_Automateddirectdebit_Job_DirectDebitEvents_PaymentCollectionEvent {
       ->join('ppea', 'INNER JOIN civicrm_value_payment_plan_extra_attributes ppea ON cr.id = ppea.entity_id')
       ->join('epi', 'LEFT JOIN civicrm_value_external_dd_payment_information epi ON c.id = epi.entity_id')
       ->where("mandate.mandate_id IS NOT NULL")
-      ->where("mandate.mandate_status = {$mandateActiveStatusId}")
       ->where('ppea.is_active = 1')
       ->where("cr.contribution_status_id IN ({$recurContributionStatusesToProcess})")
       ->where('mandate.next_available_payment_date IS NOT NULL')
-      ->where('c.receive_date >= mandate.next_available_payment_date')
       ->where("c.receive_date < DATE_ADD(CURDATE(), INTERVAL 1 DAY)")
       ->where('epi.payment_in_progress = 0 OR epi.payment_in_progress IS NULL')
-      ->where("cr.failure_count <= {$failureRetryCount}")
       ->select('c.id as contribution_id, c.contact_id, c.receive_date, c.total_amount, c.currency, mandate.mandate_id');
 
     return $query;
@@ -64,7 +54,7 @@ class CRM_Automateddirectdebit_Job_DirectDebitEvents_PaymentCollectionEvent {
 
   private function getRecurContributionStatusesIdsToProcess() {
     $allStatuses = CRM_Core_OptionGroup::values('contribution_recur_status', FALSE, FALSE, FALSE, NULL, 'name');
-    $statusesNamesToProcess = ['Pending', 'In Progress', 'Overdue'];
+    $statusesNamesToProcess = ['In Progress', 'Overdue'];
     $statusesIdsToProcess = [];
     foreach ($allStatuses as $key => $val) {
       if (array_search($val, $statusesNamesToProcess) !== FALSE) {


### PR DESCRIPTION
## Overview

As per our last discussion, we came to the conclusion that we should limit the number of variables that control the payment collection scheduled job, as it would be more advantageous to the user given there will be less things that might go wrong, and so we agreed to remove the following conditions:

1- Checking if the "Mandate Status" is active.
2- Checking if the Contribution date "receive date" >= Mandate next available payment data.
3- Checking if recurring contribution failure_count field <= "payment collection retry count" setting

The above changes put more emphasis on the recurring contribution status to be the most prominent control point of the payment collection job, and because of that we removed the "Pending" status from the list of recurring contribution statuses we process so only "In progress" and "Overdue" statuses will be processed, it also means (and we already agreed on that) that we will need to do some changes in GoCardless extension to make sure it updates the recurring contribution status correctly, for example if the mandate status changed then that should be reflected on the recurring contribution status, or if GoCardless failed to create the payment number of times that is <= "payment collection retry count" setting then it should also change the recurring contribution status to "Failed" and so on. 

All of the above means if something went wrong collecting payments for any payment plan, the user can simply look at the recurring contribution status and then do something about it, for example they want to force payments to be taken for the recurring contribution ? they can simply change the status from "failed" (or any other status) to "In progress", Or do they want to prevent payments from being submitted for certain recurring contribution ? they can just change its status from either "In progress" or "Overdue" to maybe "Pending" or "Completed" or maybe even "Cancelled".


