### PR TITLE
CIWEMB-407: Add confirmed status

### DIFF
--- a/xml/ExternalPaymentInformationCustomGroup_install.xml
+++ b/xml/ExternalPaymentInformationCustomGroup_install.xml
@@ -117,5 +117,16 @@
       <is_active>1</is_active>
       <option_group_name>automateddirectdebit_external_payment_status</option_group_name>
     </OptionValue>
+    <OptionValue>
+      <name>confirmed</name>
+      <label>Confirmed</label>
+      <value>6</value>
+      <is_default>0</is_default>
+      <weight>6</weight>
+      <is_optgroup>0</is_optgroup>
+      <is_reserved>1</is_reserved>
+      <is_active>1</is_active>
+      <option_group_name>automateddirectdebit_external_payment_status</option_group_name>
+    </OptionValue>
   </OptionValues>
 </CustomData>


### PR DESCRIPTION
## Overview

This PR adds Confirmed option to the external payment status. 

## Before

No confirmed option in the list. 

## After

![screenshot-dev localhost_8020-2023 08 16-16_37_31](https://github.com/compucorp/io.compuco.automateddirectdebit/assets/208713/35f87476-1347-4581-8874-fc6332edcd5c)
