### PR TITLE
CIWEMB-471: Fix the amount when adding membership line to current peiod after switching to direct debit

### DIFF
--- a/Civi/Api4/Action/AutoDirectDebitPaymentPlan/SwitchToDirectDebitPaymentScheme.php
+++ b/Civi/Api4/Action/AutoDirectDebitPaymentPlan/SwitchToDirectDebitPaymentScheme.php
@@ -70,7 +70,6 @@ class SwitchToDirectDebitPaymentScheme extends \Civi\Api4\Generic\AbstractAction
 
     return \Civi\Api4\ContributionRecur::update(FALSE)
       ->addValue('payment_processor_id', $newPaymentProcessorId)
-      ->addValue('installments', NULL)
       ->addValue('frequency_unit', NULL)
       ->addValue('frequency_interval', NULL)
       ->addValue('payment_plan_extra_attributes.payment_scheme_id', $this->paymentSchemeID)

--- a/tests/phpunit/CRM/Api4/AutoDirectDebitPaymentPlanTest.php
+++ b/tests/phpunit/CRM/Api4/AutoDirectDebitPaymentPlanTest.php
@@ -52,12 +52,11 @@ class CRM_Api4_AutoDirectDebitPaymentPlanTest extends BaseHeadlessTest {
 
   public function testSwitchToDirectDebitPaymentSchemeWillUnsetIrrelevantRecurringContributionFields() {
     $recurringContributionAfterSwitch = \Civi\Api4\ContributionRecur::get()
-      ->addSelect('installments', 'frequency_unit', 'frequency_interval')
+      ->addSelect('frequency_unit', 'frequency_interval')
       ->addWhere('id', '=', $this->recurringContribution['id'])
       ->setLimit(1)
       ->execute()[0];
 
-    $this->assertEmpty($recurringContributionAfterSwitch['installments']);
     $this->assertEmpty($recurringContributionAfterSwitch['frequency_unit']);
     $this->assertEmpty($recurringContributionAfterSwitch['frequency_interval']);
   }


### PR DESCRIPTION
## Before
When switching a payment plan to use direct debit payment scheme then trying to add a  membership line item to the current period tab, the membership amount that shows up will be the full membership amount instead of the amount divided by number of instalments.

![2023-09-02 01_01_06-Settings](https://github.com/compucorp/io.compuco.automateddirectdebit/assets/6275540/e3cc7302-d965-4f4f-ae76-67385d2ccf91)

## After

The correct amount shows up when trying to add a membership line item, which is the membership amount divided by number of instalments:


![2023-09-02 01_01_53-xadsadsa dsaasd _ compuclient22sspv3](https://github.com/compucorp/io.compuco.automateddirectdebit/assets/6275540/0c959c4d-1bd9-4a83-936b-4dc334df60dd)



## Technical Details

We decided to unset the following fields when switching a payment plan to direct debit payment scheme:

- installments
- frequency_unit
- frequency_interval

because they are irrelevant to payment plans that use payment schemes, but the problem is that after switching such payment plans, the use of the payment scheme only kicks in after the first autorenewal, so until then the user should still be able to add membership lines to the current period, and such line items should respect the number of instalments that on the current payment plan, but because we unset it as parting of the switching API, it is treated in Membershipextras as an annual payment plan with single instalment, which result in always showing the membership full amount when trying to add a membership line. 

Here I've updated the switching API, so it is no longer touch the `installments` field and keep its original value as is.