### PR TITLE
CIWEMB-490: Make the 'retry count' field accepts positive integers only

### DIFF
--- a/settings/AutomatedDirectDebit.setting.php
+++ b/settings/AutomatedDirectDebit.setting.php
@@ -10,9 +10,12 @@ return [
     'name' => 'automateddirectdebit_paymentplan_payment_collection_retry_count',
     'title' => 'Payment collection number of retry attempts',
     'type' => 'Integer',
-    'html_type' => 'text',
+    'html_type' => 'number',
     'quick_form_type' => 'Element',
     'default' => 3,
     'is_required' => TRUE,
+    'attributes' => [
+      'min' => 0,
+    ],
   ],
 ];


### PR DESCRIPTION
## Before


The "Payment collection number of retry attempts" field is a text field that accepts any alphanumeric string where it should only accepts positive integers:


![befff](https://github.com/compucorp/io.compuco.automateddirectdebit/assets/6275540/3a63feed-9a14-4823-8844-ccdac3c3f2b7)



## After

The  "Payment collection number of retry attempts" field only accepts positive integers:

![after](https://github.com/compucorp/io.compuco.automateddirectdebit/assets/6275540/e1d01ed1-e933-4205-a49e-e1c534e7bfe4)


## Technical details

I both changed the field html_type to `number` and added an attribute to limit the min value to 0, but the extra attribute bit only work with the update I did here in Membershipextras: https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/503/commits/aab9517171d562e2c3e4435c2e156c1142b0e0df