### PR TITLE
PROD-248: Add recurring contribution status 'pending' as a trigger to attempt to take non bacs payment 

### DIFF
--- a/CRM/Automateddirectdebit/Setup/Configure/AddMandateSchemetoDDMandateInformation.php
+++ b/CRM/Automateddirectdebit/Setup/Configure/AddMandateSchemetoDDMandateInformation.php
@@ -1,0 +1,42 @@
+<?php
+
+use CRM_MembershipExtras_Setup_Configure_ConfigurerInterface as ConfigureInterface;
+
+/**
+ * Managing 'External Direct Debit Mandate information -> Scheme' custom field.
+ */
+class CRM_Automateddirectdebit_Setup_Configure_AddMandateSchemetoDDMandateInformation implements ConfigureInterface {
+
+  const GROUP_NAME = 'external_direct_debit_mandate_information';
+  const FIELD_NAME = 'mandate_scheme';
+
+  /**
+   * @inheritDoc
+   */
+  public function apply() {
+
+    $customField = \Civi\Api4\CustomField::get(FALSE)
+      ->addWhere('custom_group_id:name', '=', self::GROUP_NAME)
+      ->addWhere('name', '=', self::FIELD_NAME)
+      ->execute()
+      ->first();
+
+    if (empty($customField)) {
+      \Civi\Api4\CustomField::create(FALSE)
+        ->addValue('custom_group_id.name', self::GROUP_NAME)
+        ->addValue('name', self::FIELD_NAME)
+        ->addValue('label', 'Mandate Scheme')
+        ->addValue('html_type', 'Text')
+        ->addValue('data_type', 'String')
+        ->addValue('is_required', FALSE)
+        ->addValue('is_searchable', TRUE)
+        ->addValue('is_search_range', FALSE)
+        ->addValue('is_view', TRUE)
+        ->addValue('column_name', self::FIELD_NAME)
+        ->execute();
+    }
+
+    return TRUE;
+  }
+
+}

--- a/CRM/Automateddirectdebit/Setup/Manage/CustomGroup/ExternalDDMandateInformation.php
+++ b/CRM/Automateddirectdebit/Setup/Manage/CustomGroup/ExternalDDMandateInformation.php
@@ -23,6 +23,7 @@ class CRM_Automateddirectdebit_Setup_Manage_CustomGroup_ExternalDDMandateInforma
   public function remove() {
     $customFields = [
       'mandate_id',
+      'mandate_scheme',
       'mandate_status',
       'next_available_payment_date',
     ];

--- a/CRM/Automateddirectdebit/Upgrader.php
+++ b/CRM/Automateddirectdebit/Upgrader.php
@@ -54,4 +54,12 @@ class CRM_Automateddirectdebit_Upgrader extends CRM_Extension_Upgrader_Base {
     }
   }
 
+  public function upgrade_1000() {
+    $this->ctx->log->info('Applying update 1000');
+
+    (new CRM_Automateddirectdebit_Setup_Configure_AddMandateSchemetoDDMandateInformation())->apply();
+
+    return TRUE;
+  }
+
 }

--- a/Civi/Api4/Action/AutoDirectDebitPaymentPlan/SwitchToDirectDebitPaymentScheme.php
+++ b/Civi/Api4/Action/AutoDirectDebitPaymentPlan/SwitchToDirectDebitPaymentScheme.php
@@ -52,6 +52,12 @@ class SwitchToDirectDebitPaymentScheme extends \Civi\Api4\Generic\AbstractAction
    * @var string
    * @required
    */
+  protected $mandateScheme;
+
+  /**
+   * @var string
+   * @required
+   */
   protected $nextAvailablePaymentDate;
 
   /**
@@ -75,6 +81,7 @@ class SwitchToDirectDebitPaymentScheme extends \Civi\Api4\Generic\AbstractAction
       ->addValue('payment_plan_extra_attributes.payment_scheme_id', $this->paymentSchemeID)
       ->addValue('external_direct_debit_mandate_information.mandate_id', $this->mandateId)
       ->addValue('external_direct_debit_mandate_information.mandate_status', $this->mandateStatus)
+      ->addValue('external_direct_debit_mandate_information.mandate_scheme', strtolower($this->mandateScheme))
       ->addValue('external_direct_debit_mandate_information.next_available_payment_date', $this->nextAvailablePaymentDate)
       ->addWhere('id', '=', $this->contributionRecurId)
       ->execute();

--- a/tests/phpunit/CRM/Api4/AutoDirectDebitPaymentPlanTest.php
+++ b/tests/phpunit/CRM/Api4/AutoDirectDebitPaymentPlanTest.php
@@ -10,7 +10,7 @@ class CRM_Api4_AutoDirectDebitPaymentPlanTest extends BaseHeadlessTest {
 
   private $paymentScheme;
 
-  public function setUp() {
+  public function setUp(): void {
     $this->recurringContribution = \Civi\Api4\ContributionRecur::create()
       ->addValue('contact_id', 1)
       ->addValue('amount', 100)
@@ -35,6 +35,7 @@ class CRM_Api4_AutoDirectDebitPaymentPlanTest extends BaseHeadlessTest {
       ->setContributionRecurId($this->recurringContribution['id'])
       ->setPaymentSchemeID($this->paymentScheme['id'])
       ->setMandateId('MAND_00001')
+      ->setMandateScheme('bacs')
       ->setMandateStatus(1)
       ->setNextAvailablePaymentDate('2023-01-01')
       ->execute();
@@ -75,11 +76,13 @@ class CRM_Api4_AutoDirectDebitPaymentPlanTest extends BaseHeadlessTest {
     $recurringContributionAfterSwitch = \Civi\Api4\ContributionRecur::get()
       ->addSelect('external_direct_debit_mandate_information.mandate_id')
       ->addSelect('external_direct_debit_mandate_information.mandate_status')
+      ->addSelect('external_direct_debit_mandate_information.mandate_scheme')
       ->addSelect('external_direct_debit_mandate_information.next_available_payment_date')
       ->addWhere('id', '=', $this->recurringContribution['id'])
       ->setLimit(1)
       ->execute()[0];
 
+    $this->assertEquals('bacs', $recurringContributionAfterSwitch['external_direct_debit_mandate_information.mandate_scheme']);
     $this->assertEquals('MAND_00001', $recurringContributionAfterSwitch['external_direct_debit_mandate_information.mandate_id']);
     $this->assertEquals(1, $recurringContributionAfterSwitch['external_direct_debit_mandate_information.mandate_status']);
     $this->assertEquals('2023-01-01', $recurringContributionAfterSwitch['external_direct_debit_mandate_information.next_available_payment_date']);

--- a/xml/ExternalMandateInformationCustomGroup_install.xml
+++ b/xml/ExternalMandateInformationCustomGroup_install.xml
@@ -70,6 +70,25 @@
       <custom_group_name>external_direct_debit_mandate_information</custom_group_name>
       <in_selector>1</in_selector>
     </CustomField>
+    <CustomField>
+      <name>mandate_scheme</name>
+      <label>Mandate Scheme</label>
+      <data_type>String</data_type>
+      <html_type>Text</html_type>
+      <is_required>0</is_required>
+      <is_searchable>1</is_searchable>
+      <is_search_range>0</is_search_range>
+      <weight>1</weight>
+      <is_active>1</is_active>
+      <is_view>0</is_view>
+      <text_length>255</text_length>
+      <note_columns>60</note_columns>
+      <note_rows>4</note_rows>
+      <column_name>mandate_scheme</column_name>
+      <custom_group_name>external_direct_debit_mandate_information</custom_group_name>
+      <in_selector>1</in_selector>
+      <is_reserved>1</is_reserved>
+    </CustomField>
   </CustomFields>
   <OptionGroups>
     <OptionGroup>

--- a/xml/ExternalMandateInformationCustomGroup_install.xml
+++ b/xml/ExternalMandateInformationCustomGroup_install.xml
@@ -80,7 +80,7 @@
       <is_search_range>0</is_search_range>
       <weight>1</weight>
       <is_active>1</is_active>
-      <is_view>0</is_view>
+      <is_view>1</is_view>
       <text_length>255</text_length>
       <note_columns>60</note_columns>
       <note_rows>4</note_rows>


### PR DESCRIPTION
## Overview

This PR builds on the updates introduced in [this previous pull request](https://github.com/compucorp/io.compuco.automateddirectdebit/pull/11), where we modified the payment processor to trigger payment events only for active contribution invoices. Specifically, this affected recurring contributions (subscriptions) with statuses of `in progress` or `overdue`. While this change worked for BACS direct debit payments, it did not account for other payment schemes like SEPA, which require the first payment for a subscription to transition into an active state.

In this PR, we address that limitation by allowing payment events to be triggered for pending subscriptions, as long as their payment scheme is not BACS (including cases where the payment scheme is set to NULL).

For subscriptions with a NULL payment scheme, we use the updated payment scheme before processing. If the updated payment scheme is BACS and the mandate status remains pending, the payment will not be processed. However, if the updated scheme is not BACS and the mandate status is pending, an attempt will be made to process the payment. For more details, refer to the implementation in this [related PR](https://github.com/compucorp/io.compuco.gocardless/pull/145).

Additionally, it is important to note that an active subscription automatically corresponds to an active mandate, and vice versa.