### PR TITLE
CIVIPLMMI-244: Add payment lock expiry to prevent stuck contributions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,83 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+CiviCRM extension (`io.compuco.automateddirectdebit`) for automated direct debit payment processing. Enables recurring contributions to switch to direct debit payment schemes (BACS, SEPA, PAD) and automates payment collection through external payment processors.
+
+**Dependency:** Requires `uk.co.compucorp.membershipextras` extension.
+
+## Commands
+
+### Testing
+```bash
+# Run all tests
+phpunit5
+
+# Run a single test file
+phpunit5 tests/phpunit/CRM/Api4/AutoDirectDebitPaymentPlanTest.php
+
+# Run a specific test method
+phpunit5 --filter testSwitchToDirectDebitPaymentSchemeActionSuccess
+```
+
+### Linting
+```bash
+# Install linter (first time setup)
+./bin/install-php-linter
+
+# Check code style
+./bin/phpcs.phar --standard=phpcs-ruleset.xml <file-or-directory>
+
+# Auto-fix code style issues
+./bin/phpcbf.phar --standard=phpcs-ruleset.xml <file-or-directory>
+```
+
+### CI Environment
+Tests run in `compucorp/civicrm-buildkit:1.3.1-php8.0` container with CiviCRM 5.51.3 (patched) on Drupal 7.
+
+## Architecture
+
+### Namespace Conventions
+- **PSR-0:** `CRM_Automateddirectdebit_*` classes in `CRM/Automateddirectdebit/`
+- **PSR-4:** `Civi\*` classes in `Civi/`
+
+### Core Components
+
+**Payment Collection Job** (`CRM/Automateddirectdebit/Job/DirectDebitEvents/PaymentCollectionEvent.php`):
+- Fetches pending invoices (BACS vs other schemes have different query logic)
+- Dispatches `automateddirectdebit_PaymentCollectionEvent` hook for payment processors to handle
+- Uses CiviCRM lock manager to prevent concurrent execution
+- Tracks payment state via custom fields: `payment_in_progress`, `payment_in_progress_at`
+
+**API v4 Action** (`Civi/Api4/Action/AutoDirectDebitPaymentPlan/SwitchToDirectDebitPaymentScheme.php`):
+- Switches recurring contributions to direct debit payment schemes
+- Validates mandate status and scheme compatibility
+
+**Setup System** (`CRM/Automateddirectdebit/Setup/`):
+- `Manage/` - Entity lifecycle managers for custom groups and scheduled jobs (Abstract Manager pattern)
+- `Configure/` - Configuration steps implementing `ConfigurerInterface`
+
+### Custom Database Tables
+- `civicrm_value_external_dd_mandate_information` - Mandate tracking (scheme, status, next available date)
+- `civicrm_value_external_dd_payment_information` - Payment state tracking (in_progress flag, timestamps)
+
+### Hook Integration
+Payment processors (e.g., GoCardless) implement `automateddirectdebit_PaymentCollectionEvent` hook to receive pending contributions and process payments.
+
+## Testing Patterns
+
+Tests use CiviCRM's headless testing framework:
+```php
+class MyTest extends BaseHeadlessTest {
+    // Extends Civi\Test\HeadlessInterface and TransactionalInterface
+    // Each test runs in isolated transaction
+}
+```
+
+Create test data using CiviCRM API v4:
+```php
+Contact::create()->setValues([...])->execute();
+Contribution::create()->setValues([...])->execute();
+```

--- a/CRM/Automateddirectdebit/Job/DirectDebitEvents/PaymentCollectionEvent.php
+++ b/CRM/Automateddirectdebit/Job/DirectDebitEvents/PaymentCollectionEvent.php
@@ -12,6 +12,16 @@ class CRM_Automateddirectdebit_Job_DirectDebitEvents_PaymentCollectionEvent {
   const BASC_PAYMENT_SCHEME = "bacs";
 
   /**
+   * Minutes after which a locked contribution becomes eligible for retry.
+   */
+  const LOCK_RETRY_WINDOW_START_MINUTES = 30;
+
+  /**
+   * Minutes after which a locked contribution is permanently excluded.
+   */
+  const LOCK_PERMANENT_FAILURE_MINUTES = 90;
+
+  /**
    * Cache for status IDs to avoid repeated DB queries.
    *
    * @var array
@@ -64,8 +74,12 @@ class CRM_Automateddirectdebit_Job_DirectDebitEvents_PaymentCollectionEvent {
       ->where("cr.contribution_status_id IN (@recur_statuses)", ["recur_statuses" => $recurContributionStatusIds])
       ->where("c.contribution_status_id IN (@contrib_statuses)", ["contrib_statuses" => $contributionStatusIds])
       ->where("c.receive_date < DATE_ADD(CURDATE(), INTERVAL 1 DAY)")
-      ->where("epi.payment_in_progress = 0 OR epi.payment_in_progress IS NULL")
-      ->select("c.id as contribution_id, c.contact_id, c.receive_date, c.total_amount, c.currency, mandate.mandate_id");
+      ->where('epi.payment_in_progress = 0
+        OR epi.payment_in_progress IS NULL
+        OR (epi.payment_in_progress = 1
+            AND epi.payment_in_progress_at < DATE_SUB(NOW(), INTERVAL ' . self::LOCK_RETRY_WINDOW_START_MINUTES . ' MINUTE)
+            AND epi.payment_in_progress_at >= DATE_SUB(NOW(), INTERVAL ' . self::LOCK_PERMANENT_FAILURE_MINUTES . ' MINUTE))')
+      ->select('c.id as contribution_id, c.contact_id, c.receive_date, c.total_amount, c.currency, mandate.mandate_id');
 
     return $query;
   }
@@ -92,7 +106,11 @@ class CRM_Automateddirectdebit_Job_DirectDebitEvents_PaymentCollectionEvent {
       ->where("cr.contribution_status_id IN (@recur_statuses)", ["recur_statuses" => $recurContributionStatusIds])
       ->where("c.contribution_status_id IN (@contrib_statuses)", ["contrib_statuses" => $contributionStatusIds])
       ->where("c.receive_date < DATE_ADD(CURDATE(), INTERVAL 1 DAY)")
-      ->where("epi.payment_in_progress = 0 OR epi.payment_in_progress IS NULL")
+      ->where('epi.payment_in_progress = 0
+        OR epi.payment_in_progress IS NULL
+        OR (epi.payment_in_progress = 1
+            AND epi.payment_in_progress_at < DATE_SUB(NOW(), INTERVAL ' . self::LOCK_RETRY_WINDOW_START_MINUTES . ' MINUTE)
+            AND epi.payment_in_progress_at >= DATE_SUB(NOW(), INTERVAL ' . self::LOCK_PERMANENT_FAILURE_MINUTES . ' MINUTE))')
       ->select("c.id as contribution_id, c.contact_id, c.receive_date, c.total_amount, c.currency, mandate.mandate_id");
 
     return $query;
@@ -127,16 +145,46 @@ class CRM_Automateddirectdebit_Job_DirectDebitEvents_PaymentCollectionEvent {
   }
 
   /**
-   * Sets  the contribution "Payment In Progress" to True to prevent
+   * Sets the contribution "Payment In Progress" to True to prevent
    * this class from trying to submit more than one payment against the
    * same contribution.
    *
-   * @param $contributionId
+   * Timestamp logic:
+   * - New record: set timestamp to NOW()
+   * - Existing with flag=0 (new payment cycle): reset timestamp to NOW()
+   * - Existing with flag=1 (retry): keep original timestamp
+   *
+   * @param int $contributionId
    * @return void
    */
   private function markContributionExternalPaymentToBeInProgress($contributionId) {
-    $query = "INSERT INTO civicrm_value_external_dd_payment_information (entity_id, payment_in_progress) VALUES({$contributionId}, 1) ON DUPLICATE KEY UPDATE payment_in_progress= 1";
-    CRM_Core_DAO::executeQuery($query);
+    $params = [1 => [$contributionId, 'Integer']];
+
+    $existing = CRM_Core_DAO::executeQuery(
+      "SELECT payment_in_progress FROM civicrm_value_external_dd_payment_information WHERE entity_id = %1",
+      $params
+    )->fetchAll();
+
+    $recordExists = !empty($existing);
+    $isAlreadyLocked = $recordExists && $existing[0]['payment_in_progress'] == 1;
+
+    if (!$recordExists) {
+      CRM_Core_DAO::executeQuery(
+        "INSERT INTO civicrm_value_external_dd_payment_information
+         (entity_id, payment_in_progress, payment_in_progress_at)
+         VALUES (%1, 1, NOW())",
+        $params
+      );
+    }
+    elseif (!$isAlreadyLocked) {
+      CRM_Core_DAO::executeQuery(
+        "UPDATE civicrm_value_external_dd_payment_information
+         SET payment_in_progress = 1, payment_in_progress_at = NOW()
+         WHERE entity_id = %1",
+        $params
+      );
+    }
+    // If already locked (retry), no update needed - keep original timestamp
   }
 
   private function dispatchPaymentCollectionEventHook($pendingInvoiceData) {

--- a/CRM/Automateddirectdebit/Job/DirectDebitEvents/PaymentCollectionEvent.php
+++ b/CRM/Automateddirectdebit/Job/DirectDebitEvents/PaymentCollectionEvent.php
@@ -9,7 +9,7 @@
  */
 class CRM_Automateddirectdebit_Job_DirectDebitEvents_PaymentCollectionEvent {
 
-  const BASC_PAYMENT_SCHEME = "bacs";
+  const BACS_PAYMENT_SCHEME = "bacs";
 
   /**
    * Minutes after which a locked contribution becomes eligible for retry.
@@ -54,7 +54,7 @@ class CRM_Automateddirectdebit_Job_DirectDebitEvents_PaymentCollectionEvent {
 
   /**
    * Builds the query to fetch the contributions (invoices)
-   * with BACS payment shceme and that
+   * with BACS payment scheme and that
    * match the criteria of direct debit payment invoices
    *
    * @return CRM_Utils_SQL_Select
@@ -69,7 +69,7 @@ class CRM_Automateddirectdebit_Job_DirectDebitEvents_PaymentCollectionEvent {
       ->join("ppea", "INNER JOIN civicrm_value_payment_plan_extra_attributes ppea ON cr.id = ppea.entity_id")
       ->join("epi", "LEFT JOIN civicrm_value_external_dd_payment_information epi ON c.id = epi.entity_id")
       ->where("mandate.mandate_id IS NOT NULL")
-      ->where("mandate.mandate_scheme = @scheme", ["scheme" => self::BASC_PAYMENT_SCHEME])
+      ->where("mandate.mandate_scheme = @scheme", ["scheme" => self::BACS_PAYMENT_SCHEME])
       ->where("ppea.is_active = 1")
       ->where("cr.contribution_status_id IN (@recur_statuses)", ["recur_statuses" => $recurContributionStatusIds])
       ->where("c.contribution_status_id IN (@contrib_statuses)", ["contrib_statuses" => $contributionStatusIds])
@@ -86,7 +86,7 @@ class CRM_Automateddirectdebit_Job_DirectDebitEvents_PaymentCollectionEvent {
 
   /**
    * Builds the query to fetch the contributions (invoices)
-   * with NON-BACS payment shceme (e.g. SEPA, PAD) and that
+   * with NON-BACS payment scheme (e.g. SEPA, PAD) and that
    * match the criteria of direct debit payment invoices
    *
    * @return CRM_Utils_SQL_Select
@@ -101,7 +101,7 @@ class CRM_Automateddirectdebit_Job_DirectDebitEvents_PaymentCollectionEvent {
       ->join("ppea", "INNER JOIN civicrm_value_payment_plan_extra_attributes ppea ON cr.id = ppea.entity_id")
       ->join("epi", "LEFT JOIN civicrm_value_external_dd_payment_information epi ON c.id = epi.entity_id")
       ->where("mandate.mandate_id IS NOT NULL")
-      ->where("mandate.mandate_scheme IS NULL OR mandate.mandate_scheme <> @scheme", ["scheme" => self::BASC_PAYMENT_SCHEME])
+      ->where("mandate.mandate_scheme IS NULL OR mandate.mandate_scheme <> @scheme", ["scheme" => self::BACS_PAYMENT_SCHEME])
       ->where("ppea.is_active = 1")
       ->where("cr.contribution_status_id IN (@recur_statuses)", ["recur_statuses" => $recurContributionStatusIds])
       ->where("c.contribution_status_id IN (@contrib_statuses)", ["contrib_statuses" => $contributionStatusIds])

--- a/CRM/Automateddirectdebit/Setup/Manage/CustomGroup/ExternalDDPaymentInformation.php
+++ b/CRM/Automateddirectdebit/Setup/Manage/CustomGroup/ExternalDDPaymentInformation.php
@@ -24,6 +24,7 @@ class CRM_Automateddirectdebit_Setup_Manage_CustomGroup_ExternalDDPaymentInforma
     $customFields = [
       'last_payment_status',
       'payment_in_progress',
+      'payment_in_progress_at',
     ];
     foreach ($customFields as $customFieldName) {
       civicrm_api3('CustomField', 'get', [

--- a/managed/PaymentInProgressAtCustomField.mgd.php
+++ b/managed/PaymentInProgressAtCustomField.mgd.php
@@ -1,0 +1,26 @@
+<?php
+
+return [
+  [
+    'name' => 'CustomField_payment_in_progress_at',
+    'entity' => 'CustomField',
+    'cleanup' => 'unused',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'custom_group_id.name' => 'external_dd_payment_information',
+        'name' => 'payment_in_progress_at',
+        'label' => 'Payment in progress since',
+        'data_type' => 'Date',
+        'html_type' => 'Select Date',
+        'date_format' => 'yy-mm-dd',
+        'time_format' => 2,
+        'column_name' => 'payment_in_progress_at',
+        'is_view' => TRUE,
+        'is_searchable' => FALSE,
+      ],
+      'match' => ['custom_group_id', 'name'],
+    ],
+  ],
+];

--- a/tests/phpunit/CRM/Automateddirectdebit/Job/PaymentCollectionEventTest.php
+++ b/tests/phpunit/CRM/Automateddirectdebit/Job/PaymentCollectionEventTest.php
@@ -1,0 +1,270 @@
+<?php
+
+/**
+ * Unit tests for PaymentCollectionEvent
+ * @group headless
+ */
+class CRM_Automateddirectdebit_Job_PaymentCollectionEventTest extends BaseHeadlessTest {
+
+  private $paymentCollectionEvent;
+
+  public function setUp(): void {
+    parent::setUp();
+    $this->paymentCollectionEvent = new CRM_Automateddirectdebit_Job_DirectDebitEvents_PaymentCollectionEvent();
+  }
+
+  /**
+   * Test timestamp is set on first lock.
+   */
+  public function testMarkInProgressSetsTimestampOnFirstLock() {
+    $contributionId = $this->createTestContribution();
+
+    $this->invokeMethod('markContributionExternalPaymentToBeInProgress', [$contributionId]);
+
+    $results = CRM_Core_DAO::executeQuery(
+      "SELECT payment_in_progress, payment_in_progress_at
+       FROM civicrm_value_external_dd_payment_information
+       WHERE entity_id = %1",
+      [1 => [$contributionId, 'Integer']]
+    )->fetchAll();
+
+    $this->assertCount(1, $results);
+    $this->assertEquals(1, $results[0]['payment_in_progress']);
+    $this->assertNotNull($results[0]['payment_in_progress_at']);
+  }
+
+  /**
+   * Test timestamp is preserved on retry (when flag was already 1).
+   */
+  public function testMarkInProgressPreservesTimestampOnRetry() {
+    $contributionId = $this->createTestContribution();
+    $originalTimestamp = '2025-01-01 10:00:00';
+
+    // Set initial lock with old timestamp
+    CRM_Core_DAO::executeQuery(
+      "INSERT INTO civicrm_value_external_dd_payment_information
+       (entity_id, payment_in_progress, payment_in_progress_at)
+       VALUES (%1, 1, %2)",
+      [
+        1 => [$contributionId, 'Integer'],
+        2 => [$originalTimestamp, 'String'],
+      ]
+    );
+
+    // Call mark in progress again (simulating retry)
+    $this->invokeMethod('markContributionExternalPaymentToBeInProgress', [$contributionId]);
+
+    $result = CRM_Core_DAO::singleValueQuery(
+      "SELECT payment_in_progress_at
+       FROM civicrm_value_external_dd_payment_information
+       WHERE entity_id = %1",
+      [1 => [$contributionId, 'Integer']]
+    );
+
+    $this->assertEquals($originalTimestamp, $result);
+  }
+
+  /**
+   * Test timestamp is reset on new payment cycle (when flag was 0).
+   */
+  public function testMarkInProgressResetsTimestampOnNewPaymentCycle() {
+    $contributionId = $this->createTestContribution();
+    $oldTimestamp = '2025-01-01 10:00:00';
+
+    // Set previous successful payment (flag = 0, but timestamp exists)
+    CRM_Core_DAO::executeQuery(
+      "INSERT INTO civicrm_value_external_dd_payment_information
+       (entity_id, payment_in_progress, payment_in_progress_at)
+       VALUES (%1, 0, %2)",
+      [
+        1 => [$contributionId, 'Integer'],
+        2 => [$oldTimestamp, 'String'],
+      ]
+    );
+
+    // Call mark in progress for new payment cycle
+    $this->invokeMethod('markContributionExternalPaymentToBeInProgress', [$contributionId]);
+
+    $result = CRM_Core_DAO::singleValueQuery(
+      "SELECT payment_in_progress_at
+       FROM civicrm_value_external_dd_payment_information
+       WHERE entity_id = %1",
+      [1 => [$contributionId, 'Integer']]
+    );
+
+    $this->assertNotEquals($oldTimestamp, $result);
+  }
+
+  /**
+   * Test query excludes contributions locked less than 30 minutes ago.
+   */
+  public function testPendingQueryExcludesRecentlyLockedContributions() {
+    $contributionId = $this->createTestContributionWithMandate();
+
+    // Lock 10 minutes ago
+    CRM_Core_DAO::executeQuery(
+      "INSERT INTO civicrm_value_external_dd_payment_information
+       (entity_id, payment_in_progress, payment_in_progress_at)
+       VALUES (%1, 1, DATE_SUB(NOW(), INTERVAL 10 MINUTE))",
+      [1 => [$contributionId, 'Integer']]
+    );
+
+    $query = $this->paymentCollectionEvent->buildPendingBACSInvoicesQuery();
+    $results = CRM_Core_DAO::executeQuery($query->toSQL())->fetchAll();
+    $ids = array_column($results, 'contribution_id');
+
+    $this->assertNotContains($contributionId, $ids);
+  }
+
+  /**
+   * Test query includes contributions in retry window (30-90 min).
+   */
+  public function testPendingQueryIncludesContributionsInRetryWindow() {
+    $contributionId = $this->createTestContributionWithMandate();
+
+    // Lock 45 minutes ago (in retry window)
+    CRM_Core_DAO::executeQuery(
+      "INSERT INTO civicrm_value_external_dd_payment_information
+       (entity_id, payment_in_progress, payment_in_progress_at)
+       VALUES (%1, 1, DATE_SUB(NOW(), INTERVAL 45 MINUTE))",
+      [1 => [$contributionId, 'Integer']]
+    );
+
+    $query = $this->paymentCollectionEvent->buildPendingBACSInvoicesQuery();
+    $results = CRM_Core_DAO::executeQuery($query->toSQL())->fetchAll();
+    $ids = array_column($results, 'contribution_id');
+
+    $this->assertContains($contributionId, $ids);
+  }
+
+  /**
+   * Test query excludes permanently failed contributions (> 90 min).
+   */
+  public function testPendingQueryExcludesPermanentlyFailedContributions() {
+    $contributionId = $this->createTestContributionWithMandate();
+
+    // Lock 120 minutes ago (permanently failed)
+    CRM_Core_DAO::executeQuery(
+      "INSERT INTO civicrm_value_external_dd_payment_information
+       (entity_id, payment_in_progress, payment_in_progress_at)
+       VALUES (%1, 1, DATE_SUB(NOW(), INTERVAL 120 MINUTE))",
+      [1 => [$contributionId, 'Integer']]
+    );
+
+    $query = $this->paymentCollectionEvent->buildPendingBACSInvoicesQuery();
+    $results = CRM_Core_DAO::executeQuery($query->toSQL())->fetchAll();
+    $ids = array_column($results, 'contribution_id');
+
+    $this->assertNotContains($contributionId, $ids);
+  }
+
+  /**
+   * Test query excludes legacy data with NULL timestamp.
+   */
+  public function testPendingQueryExcludesLegacyNullTimestamp() {
+    $contributionId = $this->createTestContributionWithMandate();
+
+    // Legacy lock with NULL timestamp
+    CRM_Core_DAO::executeQuery(
+      "INSERT INTO civicrm_value_external_dd_payment_information
+       (entity_id, payment_in_progress, payment_in_progress_at)
+       VALUES (%1, 1, NULL)",
+      [1 => [$contributionId, 'Integer']]
+    );
+
+    $query = $this->paymentCollectionEvent->buildPendingBACSInvoicesQuery();
+    $results = CRM_Core_DAO::executeQuery($query->toSQL())->fetchAll();
+    $ids = array_column($results, 'contribution_id');
+
+    $this->assertNotContains($contributionId, $ids);
+  }
+
+  // Helper methods
+
+  /**
+   * Create a basic test contribution.
+   */
+  private function createTestContribution() {
+    $contact = \Civi\Api4\Contact::create(FALSE)
+      ->addValue('contact_type', 'Individual')
+      ->addValue('first_name', 'Test')
+      ->addValue('last_name', 'Contact')
+      ->execute()
+      ->first();
+
+    $contribution = \Civi\Api4\Contribution::create(FALSE)
+      ->addValue('contact_id', $contact['id'])
+      ->addValue('total_amount', 100)
+      ->addValue('financial_type_id', 1)
+      ->execute()
+      ->first();
+
+    return $contribution['id'];
+  }
+
+  /**
+   * Create a test contribution with all required joins for the query.
+   * (recurring contribution, mandate, payment plan attributes)
+   */
+  private function createTestContributionWithMandate() {
+    $contact = \Civi\Api4\Contact::create(FALSE)
+      ->addValue('contact_type', 'Individual')
+      ->addValue('first_name', 'Test')
+      ->addValue('last_name', 'Contact')
+      ->execute()
+      ->first();
+
+    // Create recurring contribution
+    $recurringContribution = \Civi\Api4\ContributionRecur::create(FALSE)
+      ->addValue('contact_id', $contact['id'])
+      ->addValue('amount', 100)
+      ->addValue('frequency_unit', 'month')
+      ->addValue('frequency_interval', 1)
+      ->addValue('contribution_status_id:name', 'In Progress')
+      ->execute()
+      ->first();
+
+    // Create contribution linked to recurring
+    $contribution = \Civi\Api4\Contribution::create(FALSE)
+      ->addValue('contact_id', $contact['id'])
+      ->addValue('total_amount', 100)
+      ->addValue('financial_type_id', 1)
+      ->addValue('contribution_recur_id', $recurringContribution['id'])
+      ->addValue('receive_date', 'now')
+      ->execute()
+      ->first();
+
+    // Add mandate information
+    CRM_Core_DAO::executeQuery(
+      "INSERT INTO civicrm_value_external_dd_mandate_information
+       (entity_id, mandate_id, mandate_scheme)
+       VALUES (%1, %2, %3)",
+      [
+        1 => [$recurringContribution['id'], 'Integer'],
+        2 => ['MANDATE_TEST_' . $contribution['id'], 'String'],
+        3 => ['bacs', 'String'],
+      ]
+    );
+
+    // Add payment plan extra attributes (is_active = 1)
+    CRM_Core_DAO::executeQuery(
+      "INSERT INTO civicrm_value_payment_plan_extra_attributes
+       (entity_id, is_active)
+       VALUES (%1, 1)",
+      [1 => [$recurringContribution['id'], 'Integer']]
+    );
+
+    return $contribution['id'];
+  }
+
+  /**
+   * Invoke a private method on the payment collection event object.
+   */
+  private function invokeMethod($methodName, $args = []) {
+    $reflection = new ReflectionClass($this->paymentCollectionEvent);
+    $method = $reflection->getMethod($methodName);
+    $method->setAccessible(TRUE);
+    return $method->invokeArgs($this->paymentCollectionEvent, $args);
+  }
+
+}

--- a/tests/phpunit/CRM/Automateddirectdebit/Job/PaymentCollectionEventTest.php
+++ b/tests/phpunit/CRM/Automateddirectdebit/Job/PaymentCollectionEventTest.php
@@ -230,6 +230,7 @@ class CRM_Automateddirectdebit_Job_PaymentCollectionEventTest extends BaseHeadle
       ->addValue('total_amount', 100)
       ->addValue('financial_type_id', 1)
       ->addValue('contribution_recur_id', $recurringContribution['id'])
+      ->addValue('contribution_status_id:name', 'Pending')
       ->addValue('receive_date', 'now')
       ->execute()
       ->first();


### PR DESCRIPTION
## Overview

When the Payment Collection job crashes unexpectedly, contributions get permanently stuck and are never processed again. This PR adds automatic lock expiry so stuck contributions can recover and be retried.

## Before

- Payment Collection job sets `payment_in_progress = 1` before processing
- If job crashes (timeout, OOM, process killed), flag stays at 1 forever
- Contribution is permanently excluded from future processing
- Manual database fix required to recover stuck contributions

## After

- New `payment_in_progress_at` timestamp tracks when lock was first set
- Locks automatically expire after 30 minutes, allowing retry
- After 90 minutes (3 retry windows), contribution is permanently excluded
- No manual intervention needed for crash recovery

| Time Since First Lock | Behaviour |
|----------------------|-----------|
| 0-30 min | Skip (processing or recently failed) |
| 30-90 min | Retry window (allow reprocessing) |
| > 90 min | Permanently excluded |

## Technical Details

### 1. New Custom Field (Managed Entity)

```php
// managed/PaymentInProgressAtCustomField.mgd.php
'name' => 'payment_in_progress_at',
'data_type' => 'Date',
'html_type' => 'Select Date',
'date_format' => 'yy-mm-dd',
'time_format' => 2,
```

### 2. Timestamp Logic (PHP)

```php
$existing = CRM_Core_DAO::executeQuery(
  "SELECT payment_in_progress FROM ... WHERE entity_id = %1",
  $params
)->fetchAll();

$recordExists = !empty($existing);
$isAlreadyLocked = $recordExists && $existing[0]['payment_in_progress'] == 1;

if (!$recordExists) {
  // INSERT new record with timestamp = NOW()
}
elseif (!$isAlreadyLocked) {
  // UPDATE - new payment cycle, reset timestamp to NOW()
}
// If already locked (retry), no update - keep original timestamp
```

- First lock: Set timestamp to NOW()
- Retry (flag was 1): Keep original timestamp
- New payment cycle (flag was 0): Reset to NOW()

### 3. Query WHERE Clause

```sql
WHERE epi.payment_in_progress = 0
   OR epi.payment_in_progress IS NULL
   OR (epi.payment_in_progress = 1
       AND epi.payment_in_progress_at < DATE_SUB(NOW(), INTERVAL 30 MINUTE)
       AND epi.payment_in_progress_at >= DATE_SUB(NOW(), INTERVAL 90 MINUTE))
```

### 4. Class Constants

```php
const LOCK_RETRY_WINDOW_START_MINUTES = 30;
const LOCK_PERMANENT_FAILURE_MINUTES = 90;
```

### Core overrides

None. This PR only modifies extension files.

## Comments

- Legacy data with `payment_in_progress = 1` and `NULL` timestamp will remain locked until manually reset
- Unit tests added covering all scenarios (7 tests)