### PR TITLE
COMCL-1377: Remove Unused Help File

### DIFF
--- a/templates/CRM/MembershipExtras/Form/PaymentPlanSettings.extra.hlp
+++ b/templates/CRM/MembershipExtras/Form/PaymentPlanSettings.extra.hlp
@@ -1,8 +1,0 @@
-{htxt id="automateddirectdebit_paymentplan_payment_collection_retry_count-title"}
-{ts}Payment collection number of retry attempts{/ts}
-{/htxt}
-{htxt id="automateddirectdebit_paymentplan_payment_collection_retry_count"}
-{ts}Please configure the number of retry attempts that CiviCRM will make before marking the recurring contribution as failed.{/ts}
-{ts}Note however that your payment processor, for example GoCardless, may already attempt to retry your payment before CiviCRM attempts to retry.{/ts}
-{ts}In those situations you may wish to set this to 0 as GoCardless will already have retried the payment on your behalf.{/ts}
-{/htxt}


### PR DESCRIPTION
## Overview
The help file for payment plan settings have been moved to membership extras extension in this PR https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/581 since the field was displayed on a form that is in membership extras extension so the help was not getting loaded correctly from this extension. So this PR removes the unused help file
