### PR TITLE
CIVIPLMMSR-623: Widen payment collection recurring status filters

### DIFF
--- a/CRM/Automateddirectdebit/Job/DirectDebitEvents/PaymentCollectionEvent.php
+++ b/CRM/Automateddirectdebit/Job/DirectDebitEvents/PaymentCollectionEvent.php
@@ -48,7 +48,7 @@ class CRM_Automateddirectdebit_Job_DirectDebitEvents_PaymentCollectionEvent {
    * @return CRM_Utils_SQL_Select
    */
   public function buildPendingBACSInvoicesQuery() {
-    return $this->buildPendingInvoicesQuery("mandate.mandate_scheme = @scheme", ["scheme" => self::BASC_PAYMENT_SCHEME]);
+    return $this->buildPendingInvoicesQuery(TRUE);
   }
 
   /**
@@ -57,17 +57,16 @@ class CRM_Automateddirectdebit_Job_DirectDebitEvents_PaymentCollectionEvent {
    * @return CRM_Utils_SQL_Select
    */
   public function buildPendingOtherInvoicesQuery() {
-    return $this->buildPendingInvoicesQuery("mandate.mandate_scheme IS NULL OR mandate.mandate_scheme <> @scheme", ["scheme" => self::BASC_PAYMENT_SCHEME]);
+    return $this->buildPendingInvoicesQuery(FALSE);
   }
 
   /**
    * Builds the query to fetch contributions (invoices) eligible for direct debit payment collection.
    *
-   * @param string $schemeCondition SQL WHERE clause for mandate scheme filtering
-   * @param array $schemeParams Parameters for the scheme condition
+   * @param bool $isBacs Whether to filter for BACS or non-BACS schemes
    * @return CRM_Utils_SQL_Select
    */
-  private function buildPendingInvoicesQuery(string $schemeCondition, array $schemeParams) {
+  private function buildPendingInvoicesQuery(bool $isBacs) {
     $excludedRecurStatusIds = $this->getStatusesId('contribution_recur_status', ['Cancelled', 'Failed']);
     $contributionStatusIds = $this->getStatusesId('contribution_status', ['Pending', 'Partially paid']);
 
@@ -77,7 +76,12 @@ class CRM_Automateddirectdebit_Job_DirectDebitEvents_PaymentCollectionEvent {
       ->join("ppea", "INNER JOIN civicrm_value_payment_plan_extra_attributes ppea ON cr.id = ppea.entity_id")
       ->join("epi", "LEFT JOIN civicrm_value_external_dd_payment_information epi ON c.id = epi.entity_id")
       ->where("mandate.mandate_id IS NOT NULL")
-      ->where($schemeCondition, $schemeParams)
+      ->where(
+        $isBacs
+          ? "mandate.mandate_scheme = @scheme"
+          : "mandate.mandate_scheme IS NULL OR mandate.mandate_scheme <> @scheme",
+        ["scheme" => self::BASC_PAYMENT_SCHEME]
+      )
       ->where("ppea.is_active = 1")
       ->where("cr.contribution_status_id NOT IN (@recur_statuses)", ["recur_statuses" => $excludedRecurStatusIds])
       ->where("c.contribution_status_id IN (@contrib_statuses)", ["contrib_statuses" => $contributionStatusIds])

--- a/CRM/Automateddirectdebit/Job/DirectDebitEvents/PaymentCollectionEvent.php
+++ b/CRM/Automateddirectdebit/Job/DirectDebitEvents/PaymentCollectionEvent.php
@@ -50,7 +50,7 @@ class CRM_Automateddirectdebit_Job_DirectDebitEvents_PaymentCollectionEvent {
    * @return CRM_Utils_SQL_Select
    */
   public function buildPendingBACSInvoicesQuery() {
-    $recurContributionStatusIds = $this->getStatusesId('contribution_recur_status', ['In Progress', 'Overdue']);
+    $excludedRecurStatusIds = $this->getStatusesId('contribution_recur_status', ['Cancelled', 'Failed']);
     $contributionStatusIds = $this->getStatusesId('contribution_status', ['Pending', 'Partially paid']);
 
     $query = CRM_Utils_SQL_Select::from("civicrm_contribution c")
@@ -61,7 +61,7 @@ class CRM_Automateddirectdebit_Job_DirectDebitEvents_PaymentCollectionEvent {
       ->where("mandate.mandate_id IS NOT NULL")
       ->where("mandate.mandate_scheme = @scheme", ["scheme" => self::BASC_PAYMENT_SCHEME])
       ->where("ppea.is_active = 1")
-      ->where("cr.contribution_status_id IN (@recur_statuses)", ["recur_statuses" => $recurContributionStatusIds])
+      ->where("cr.contribution_status_id NOT IN (@recur_statuses)", ["recur_statuses" => $excludedRecurStatusIds])
       ->where("c.contribution_status_id IN (@contrib_statuses)", ["contrib_statuses" => $contributionStatusIds])
       ->where("c.receive_date < DATE_ADD(CURDATE(), INTERVAL 1 DAY)")
       ->where("epi.payment_in_progress = 0 OR epi.payment_in_progress IS NULL")
@@ -78,7 +78,7 @@ class CRM_Automateddirectdebit_Job_DirectDebitEvents_PaymentCollectionEvent {
    * @return CRM_Utils_SQL_Select
    */
   public function buildPendingOtherInvoicesQuery() {
-    $recurContributionStatusIds = $this->getStatusesId('contribution_recur_status', ['In Progress', 'Overdue', 'Pending']);
+    $excludedRecurStatusIds = $this->getStatusesId('contribution_recur_status', ['Cancelled', 'Failed']);
     $contributionStatusIds = $this->getStatusesId('contribution_status', ['Pending', 'Partially paid']);
 
     $query = CRM_Utils_SQL_Select::from("civicrm_contribution c")
@@ -89,7 +89,7 @@ class CRM_Automateddirectdebit_Job_DirectDebitEvents_PaymentCollectionEvent {
       ->where("mandate.mandate_id IS NOT NULL")
       ->where("mandate.mandate_scheme IS NULL OR mandate.mandate_scheme <> @scheme", ["scheme" => self::BASC_PAYMENT_SCHEME])
       ->where("ppea.is_active = 1")
-      ->where("cr.contribution_status_id IN (@recur_statuses)", ["recur_statuses" => $recurContributionStatusIds])
+      ->where("cr.contribution_status_id NOT IN (@recur_statuses)", ["recur_statuses" => $excludedRecurStatusIds])
       ->where("c.contribution_status_id IN (@contrib_statuses)", ["contrib_statuses" => $contributionStatusIds])
       ->where("c.receive_date < DATE_ADD(CURDATE(), INTERVAL 1 DAY)")
       ->where("epi.payment_in_progress = 0 OR epi.payment_in_progress IS NULL")

--- a/CRM/Automateddirectdebit/Job/DirectDebitEvents/PaymentCollectionEvent.php
+++ b/CRM/Automateddirectdebit/Job/DirectDebitEvents/PaymentCollectionEvent.php
@@ -43,59 +43,47 @@ class CRM_Automateddirectdebit_Job_DirectDebitEvents_PaymentCollectionEvent {
   }
 
   /**
-   * Builds the query to fetch the contributions (invoices)
-   * with BACS payment shceme and that
-   * match the criteria of direct debit payment invoices
+   * Builds the query to fetch BACS contributions eligible for payment collection.
    *
    * @return CRM_Utils_SQL_Select
    */
   public function buildPendingBACSInvoicesQuery() {
-    $excludedRecurStatusIds = $this->getStatusesId('contribution_recur_status', ['Cancelled', 'Failed']);
-    $contributionStatusIds = $this->getStatusesId('contribution_status', ['Pending', 'Partially paid']);
-
-    $query = CRM_Utils_SQL_Select::from("civicrm_contribution c")
-      ->join("cr", "INNER JOIN civicrm_contribution_recur cr ON c.contribution_recur_id = cr.id")
-      ->join("mandate", "INNER JOIN civicrm_value_external_dd_mandate_information mandate ON cr.id = mandate.entity_id")
-      ->join("ppea", "INNER JOIN civicrm_value_payment_plan_extra_attributes ppea ON cr.id = ppea.entity_id")
-      ->join("epi", "LEFT JOIN civicrm_value_external_dd_payment_information epi ON c.id = epi.entity_id")
-      ->where("mandate.mandate_id IS NOT NULL")
-      ->where("mandate.mandate_scheme = @scheme", ["scheme" => self::BASC_PAYMENT_SCHEME])
-      ->where("ppea.is_active = 1")
-      ->where("cr.contribution_status_id NOT IN (@recur_statuses)", ["recur_statuses" => $excludedRecurStatusIds])
-      ->where("c.contribution_status_id IN (@contrib_statuses)", ["contrib_statuses" => $contributionStatusIds])
-      ->where("c.receive_date < DATE_ADD(CURDATE(), INTERVAL 1 DAY)")
-      ->where("epi.payment_in_progress = 0 OR epi.payment_in_progress IS NULL")
-      ->select("c.id as contribution_id, c.contact_id, c.receive_date, c.total_amount, c.currency, mandate.mandate_id");
-
-    return $query;
+    return $this->buildPendingInvoicesQuery("mandate.mandate_scheme = @scheme", ["scheme" => self::BASC_PAYMENT_SCHEME]);
   }
 
   /**
-   * Builds the query to fetch the contributions (invoices)
-   * with NON-BACS payment shceme (e.g. SEPA, PAD) and that
-   * match the criteria of direct debit payment invoices
+   * Builds the query to fetch non-BACS contributions (e.g. SEPA, PAD) eligible for payment collection.
    *
    * @return CRM_Utils_SQL_Select
    */
   public function buildPendingOtherInvoicesQuery() {
+    return $this->buildPendingInvoicesQuery("mandate.mandate_scheme IS NULL OR mandate.mandate_scheme <> @scheme", ["scheme" => self::BASC_PAYMENT_SCHEME]);
+  }
+
+  /**
+   * Builds the query to fetch contributions (invoices) eligible for direct debit payment collection.
+   *
+   * @param string $schemeCondition SQL WHERE clause for mandate scheme filtering
+   * @param array $schemeParams Parameters for the scheme condition
+   * @return CRM_Utils_SQL_Select
+   */
+  private function buildPendingInvoicesQuery(string $schemeCondition, array $schemeParams) {
     $excludedRecurStatusIds = $this->getStatusesId('contribution_recur_status', ['Cancelled', 'Failed']);
     $contributionStatusIds = $this->getStatusesId('contribution_status', ['Pending', 'Partially paid']);
 
-    $query = CRM_Utils_SQL_Select::from("civicrm_contribution c")
+    return CRM_Utils_SQL_Select::from("civicrm_contribution c")
       ->join("cr", "INNER JOIN civicrm_contribution_recur cr ON c.contribution_recur_id = cr.id")
       ->join("mandate", "INNER JOIN civicrm_value_external_dd_mandate_information mandate ON cr.id = mandate.entity_id")
       ->join("ppea", "INNER JOIN civicrm_value_payment_plan_extra_attributes ppea ON cr.id = ppea.entity_id")
       ->join("epi", "LEFT JOIN civicrm_value_external_dd_payment_information epi ON c.id = epi.entity_id")
       ->where("mandate.mandate_id IS NOT NULL")
-      ->where("mandate.mandate_scheme IS NULL OR mandate.mandate_scheme <> @scheme", ["scheme" => self::BASC_PAYMENT_SCHEME])
+      ->where($schemeCondition, $schemeParams)
       ->where("ppea.is_active = 1")
       ->where("cr.contribution_status_id NOT IN (@recur_statuses)", ["recur_statuses" => $excludedRecurStatusIds])
       ->where("c.contribution_status_id IN (@contrib_statuses)", ["contrib_statuses" => $contributionStatusIds])
       ->where("c.receive_date < DATE_ADD(CURDATE(), INTERVAL 1 DAY)")
       ->where("epi.payment_in_progress = 0 OR epi.payment_in_progress IS NULL")
       ->select("c.id as contribution_id, c.contact_id, c.receive_date, c.total_amount, c.currency, mandate.mandate_id");
-
-    return $query;
   }
 
   /**

--- a/tests/phpunit/CRM/Automateddirectdebit/Job/DirectDebitEvents/PaymentCollectionEventTest.php
+++ b/tests/phpunit/CRM/Automateddirectdebit/Job/DirectDebitEvents/PaymentCollectionEventTest.php
@@ -314,7 +314,7 @@ class CRM_Automateddirectdebit_Job_DirectDebitEvents_PaymentCollectionEventTest 
     );
   }
 
-  public function testPendingRecurringContributionIsNotIncludedInBACSQuery() {
+  public function testPendingRecurringContributionIsIncludedInBACSQuery() {
     $recurringContribution = $this->createRecurringContribution('Pending');
     $this->setupMandateInformation($recurringContribution['id'], 'TEST_MANDATE_PENDING_BACS', 'bacs');
     $this->setupPaymentPlanExtraAttributes($recurringContribution['id']);
@@ -323,9 +323,54 @@ class CRM_Automateddirectdebit_Job_DirectDebitEvents_PaymentCollectionEventTest 
 
     $contributionIds = $this->getBACSQueryContributionIds();
 
+    $this->assertTrue(
+      in_array($contribution['id'], $contributionIds),
+      'Contribution with Pending recurring status should be included in BACS query'
+    );
+  }
+
+  public function testCompletedRecurringContributionIsIncludedInBACSQuery() {
+    $recurringContribution = $this->createRecurringContribution('Completed');
+    $this->setupMandateInformation($recurringContribution['id'], 'TEST_MANDATE_COMPLETED_BACS', 'bacs');
+    $this->setupPaymentPlanExtraAttributes($recurringContribution['id']);
+
+    $contribution = $this->createContribution($recurringContribution['id'], 'Pending');
+
+    $contributionIds = $this->getBACSQueryContributionIds();
+
+    $this->assertTrue(
+      in_array($contribution['id'], $contributionIds),
+      'Contribution with Completed recurring status should be included in BACS query if it has pending contributions'
+    );
+  }
+
+  public function testCancelledRecurringContributionIsNotIncludedInBACSQuery() {
+    $recurringContribution = $this->createRecurringContribution('Cancelled');
+    $this->setupMandateInformation($recurringContribution['id'], 'TEST_MANDATE_CANCELLED_BACS', 'bacs');
+    $this->setupPaymentPlanExtraAttributes($recurringContribution['id']);
+
+    $contribution = $this->createContribution($recurringContribution['id'], 'Pending');
+
+    $contributionIds = $this->getBACSQueryContributionIds();
+
     $this->assertFalse(
       in_array($contribution['id'], $contributionIds),
-      'Contribution with Pending recurring status should NOT be included in BACS query'
+      'Contribution with Cancelled recurring status should NOT be included in BACS query'
+    );
+  }
+
+  public function testFailedRecurringContributionIsNotIncludedInBACSQuery() {
+    $recurringContribution = $this->createRecurringContribution('Failed');
+    $this->setupMandateInformation($recurringContribution['id'], 'TEST_MANDATE_FAILED_BACS', 'bacs');
+    $this->setupPaymentPlanExtraAttributes($recurringContribution['id']);
+
+    $contribution = $this->createContribution($recurringContribution['id'], 'Pending');
+
+    $contributionIds = $this->getBACSQueryContributionIds();
+
+    $this->assertFalse(
+      in_array($contribution['id'], $contributionIds),
+      'Contribution with Failed recurring status should NOT be included in BACS query'
     );
   }
 


### PR DESCRIPTION
## Overview

Widen the payment collection job queries so contributions are no longer missed due to overly restrictive recurring status filters. BACS and non-BACS now use the same unified filter.

## Before

- BACS query only picked up recurring contributions with status `In Progress` or `Overdue`
- Non-BACS query picked up `In Progress`, `Overdue`, or `Pending`
- Contributions with `Pending` (BACS) or `Completed` recurring status were silently skipped

## After

- Both BACS and non-BACS queries use `NOT IN (Cancelled, Failed)`, picking up all non-terminal recurring statuses
- BACS and non-BACS recurring status logic is now unified
- Contributions with `Pending`, `Completed`, or `Overdue` recurring status are now collected regardless of payment scheme

## Gotchas

**SIDE EFFECT** — Contributions with `Pending` or `Completed` recurring status are now picked up by the payment collection job for BACS. Previously only `In Progress` and `Overdue` were collected.

## Technical Details

The payment collection job had separate recurring status filters for BACS (`In Progress`, `Overdue`) and non-BACS (`In Progress`, `Overdue`, `Pending`), causing BACS contributions with `Pending` recurring status to be silently skipped. Changed both queries from an include-list (`IN`) to an exclude-list (`NOT IN Cancelled, Failed`), unifying the logic and ensuring all non-terminal recurring contributions are collected regardless of payment scheme.


Changed `buildPendingBACSInvoicesQuery()` and `buildPendingOtherInvoicesQuery()` in `CRM/Automateddirectdebit/Job/DirectDebitEvents/PaymentCollectionEvent.php`:
- Variable renamed from `$recurContributionStatusIds` to `$excludedRecurStatusIds`
- SQL changed from `cr.contribution_status_id IN (...)` to `cr.contribution_status_id NOT IN (...)`
- Status list changed from include-list to `['Cancelled', 'Failed']` exclude-list

### Core overrides

None.

## Testing

- [x] `testPendingRecurringContributionIsIncludedInBACSQuery` — flipped from `IsNotIncluded` (Pending BACS recurring is now picked up)
- [x] `testCompletedRecurringContributionIsIncludedInBACSQuery` — new
- [x] `testCancelledRecurringContributionIsNotIncludedInBACSQuery` — new
- [x] `testFailedRecurringContributionIsNotIncludedInBACSQuery` — new
- [x] All existing tests remain passing

## Comments

- Related Jira: [CIVIPLMMSR-623](https://compucorp.atlassian.net/browse/CIVIPLMMSR-623)
- Ref: [GoCardless Payment Collection Issues — Analysis & Status](https://compucorp.atlassian.net/wiki/spaces/CN/pages/6049792001)