### PR TITLE
LCCSPRT-108: Exclude External DD Payment Information from auto-renew copying

### DIFF
--- a/CRM/Automateddirectdebit/Hook/Listener/ExcludeAutoRenewPaymentInfoFields.php
+++ b/CRM/Automateddirectdebit/Hook/Listener/ExcludeAutoRenewPaymentInfoFields.php
@@ -1,0 +1,47 @@
+<?php
+
+use Civi\Core\Event\GenericHookEvent;
+
+/**
+ * Excludes the External DD Payment Information custom fields (notably
+ * payment_in_progress) from MembershipExtras auto-renew copying.
+ *
+ * Without this, the renewal copies the previous contribution's
+ * payment_in_progress value onto the new contribution. A stale value of 1
+ * makes the payment collection job skip the new contribution, so it is never
+ * collected and the membership silently fails to renew.
+ *
+ * Listens to CRM_MembershipExtras_Hook_CustomDispatch_AutoRenewExcludedCustomFields::NAME.
+ */
+class CRM_Automateddirectdebit_Hook_Listener_ExcludeAutoRenewPaymentInfoFields {
+
+  public static function handle(GenericHookEvent $event) {
+    $customFieldIds =& $event->customFieldIds;
+
+    foreach (self::getPaymentInfoFieldIds() as $fieldId) {
+      $customFieldIds[] = $fieldId;
+    }
+  }
+
+  /**
+   * Field IDs of the External DD Payment Information group.
+   *
+   * Cached per request: this runs once per renewal contribution copy, and the
+   * field IDs do not change within a request.
+   *
+   * @return array
+   */
+  private static function getPaymentInfoFieldIds() {
+    static $fieldIds = NULL;
+    if ($fieldIds === NULL) {
+      $fieldIds = \Civi\Api4\CustomField::get(FALSE)
+        ->addSelect('id')
+        ->addWhere('custom_group_id:name', '=', CRM_Automateddirectdebit_Setup_Manage_CustomGroup_ExternalDDPaymentInformation::GROUP_NAME)
+        ->execute()
+        ->column('id');
+    }
+
+    return $fieldIds;
+  }
+
+}

--- a/automateddirectdebit.php
+++ b/automateddirectdebit.php
@@ -15,6 +15,23 @@ function automateddirectdebit_civicrm_config(&$config) {
 }
 
 /**
+ * Implements hook_civicrm_container().
+ *
+ * Registers the listener that excludes the External DD Payment Information
+ * fields (e.g. payment_in_progress) from MembershipExtras auto-renew custom
+ * field copying. The event name is defined by
+ * CRM_MembershipExtras_Hook_CustomDispatch_AutoRenewExcludedCustomFields::NAME.
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_container/
+ */
+function automateddirectdebit_civicrm_container($container) {
+  $container->findDefinition('dispatcher')->addMethodCall('addListener', [
+    'me.autorenew.excluded_custom_fields',
+    ['CRM_Automateddirectdebit_Hook_Listener_ExcludeAutoRenewPaymentInfoFields', 'handle'],
+  ]);
+}
+
+/**
  * Implements hook_civicrm_install().
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install

--- a/tests/phpunit/CRM/Automateddirectdebit/Hook/Listener/ExcludeAutoRenewPaymentInfoFieldsTest.php
+++ b/tests/phpunit/CRM/Automateddirectdebit/Hook/Listener/ExcludeAutoRenewPaymentInfoFieldsTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use Civi\Core\Event\GenericHookEvent;
+use CRM_Automateddirectdebit_Setup_Manage_CustomGroup_ExternalDDPaymentInformation as PaymentInfoGroup;
+
+/**
+ * @group headless
+ */
+class CRM_Automateddirectdebit_Hook_Listener_ExcludeAutoRenewPaymentInfoFieldsTest extends BaseHeadlessTest {
+
+  private function getPaymentInfoFieldIds() {
+    return \Civi\Api4\CustomField::get(FALSE)
+      ->addSelect('id')
+      ->addWhere('custom_group_id:name', '=', PaymentInfoGroup::GROUP_NAME)
+      ->execute()
+      ->column('id');
+  }
+
+  public function testHandleAppendsPaymentInfoFields() {
+    $customFieldIds = [];
+    $event = GenericHookEvent::create(['customFieldIds' => &$customFieldIds]);
+
+    CRM_Automateddirectdebit_Hook_Listener_ExcludeAutoRenewPaymentInfoFields::handle($event);
+
+    $expectedFieldIds = $this->getPaymentInfoFieldIds();
+    $this->assertNotEmpty($expectedFieldIds);
+    foreach ($expectedFieldIds as $fieldId) {
+      $this->assertContains($fieldId, $customFieldIds);
+    }
+  }
+
+  public function testPaymentInProgressIsExcludedViaMembershipExtras() {
+    if (!class_exists('CRM_MembershipExtras_Hook_CustomDispatch_AutoRenewExcludedCustomFields')) {
+      $this->markTestSkipped('Requires the MembershipExtras auto-renew exclusion hook (compucorp/uk.co.compucorp.membershipextras#590).');
+    }
+
+    $excludedFieldIds = array_map('intval', CRM_MembershipExtras_SettingsManager::getCustomFieldsIdsToExcludeForAutoRenew());
+
+    $paymentInProgressField = \Civi\Api4\CustomField::get(FALSE)
+      ->addSelect('id')
+      ->addWhere('custom_group_id:name', '=', PaymentInfoGroup::GROUP_NAME)
+      ->addWhere('name', '=', 'payment_in_progress')
+      ->execute()
+      ->first();
+    $paymentInProgressFieldId = is_array($paymentInProgressField) ? (int) $paymentInProgressField['id'] : 0;
+
+    $this->assertNotEmpty($paymentInProgressFieldId);
+    $this->assertContains($paymentInProgressFieldId, $excludedFieldIds);
+  }
+
+}


### PR DESCRIPTION
## Overview

Stops the "payment in progress" flag from being copied onto renewal contributions, which was silently preventing those renewals from being collected (LCCSPRT-108).

## Before

On renewal, MembershipExtras copies all custom fields from the previous contribution to the new one, including this extension's `payment_in_progress` flag. If the previous value was left at `1` (e.g. the payment result never synced back from the processor), the new contribution is created already flagged as "payment in progress". The payment collection job only collects contributions where `payment_in_progress = 0 OR IS NULL` (`PaymentCollectionEvent`), so it skips them — they stay Pending and are never collected, and the membership silently fails to renew.

_No UI change — screenshots N/A._

## After

This extension declares its own `external_dd_payment_information` fields as excluded from auto-renew copying, by listening to the new MembershipExtras hook. Renewal contributions are created without the stale flag and get collected normally. No per-site configuration; the group is resolved by name so it is correct on every site.

_No UI change — screenshots N/A._

## Technical Details

- New listener `CRM_Automateddirectdebit_Hook_Listener_ExcludeAutoRenewPaymentInfoFields` appends the `external_dd_payment_information` field IDs to the exclusion list (cached per request, since the copier calls this once per renewal contribution).
- Registered on `me.autorenew.excluded_custom_fields` in `hook_civicrm_config`.
- No DB migration. Existing manual exclusions (LCC, IWA) are unaffected — IDs are de-duplicated.

Tests (`ExcludeAutoRenewPaymentInfoFieldsTest`): the listener appends the payment-info fields; and end-to-end, `payment_in_progress` is returned by `CRM_MembershipExtras_SettingsManager::getCustomFieldsIdsToExcludeForAutoRenew()` once the listener is registered.

### Core overrides

None.

## Comments

Depends on the MembershipExtras hook: compucorp/uk.co.compucorp.membershipextras#590 — release that first. Without it the listener simply never fires (no error). Context: LCCSPRT-108.

The end-to-end test (`testPaymentInProgressIsExcludedViaMembershipExtras`) is skipped until #590 is released (it checks for the hook class and `markTestSkipped`s if absent), since CI installs MembershipExtras from master. It will exercise the real integration automatically once #590 ships. The direct-handle test covers the listener in the meantime.
